### PR TITLE
fix: Look for documents using an ObjectId.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+fix: Look for documents using an ObjectId.
+
+IDs in MongoDB can be stored as either strings or Object IDs. This meant that if you created a document
+and let Mongo assign an id to it, Esix wouldn't be able to find it as it was only looking for the
+hex representation.
+
+With this change, `BaseModel.find(id)` will look for documents with either a matching Object id or
+a string representation of it.
+
 ## [2.2.0] - 2020-09-10
 
 ### Added

--- a/src/base-model.spec.ts
+++ b/src/base-model.spec.ts
@@ -260,7 +260,10 @@ describe('BaseModel', () => {
       const book = await Book.find('abc-123');
 
       expect(collection.findOne).toHaveBeenCalledWith({
-        _id: 'abc-123'
+        $or: [
+          { _id: ObjectId.createFromHexString('abc-123') },
+          { _id: 'abc-123' }
+        ]
       });
 
       expect(book).toBeNull();
@@ -279,7 +282,10 @@ describe('BaseModel', () => {
       const book = await Book.find('5f3568f2a0cdd1c9ba411c43');
 
       expect(collection.findOne).toHaveBeenCalledWith({
-        _id: '5f3568f2a0cdd1c9ba411c43'
+        $or: [
+          { _id: ObjectId.createFromHexString('5f3568f2a0cdd1c9ba411c43') },
+          { _id: '5f3568f2a0cdd1c9ba411c43' }
+        ]
       });
 
       expect(book).toEqual({

--- a/src/base-model.ts
+++ b/src/base-model.ts
@@ -57,10 +57,8 @@ export default class BaseModel {
    *
    * @param id
    */
-  static async find<T extends BaseModel>(this: ObjectType<T>, id?: string | number): Promise<T | null> {
-    return new QueryBuilder(this).findOne({
-      _id: id
-    });
+  static async find<T extends BaseModel>(this: ObjectType<T>, id: string): Promise<T | null> {
+    return new QueryBuilder(this).find(id);
   }
 
   /**

--- a/src/query-builder.ts
+++ b/src/query-builder.ts
@@ -100,6 +100,26 @@ export default class QueryBuilder<T> {
   }
 
   /**
+   * Returns the model with the given id or null if there is no matching model.
+   */
+  async find(id: string): Promise<T | null> {
+    return this.useCollection(async collection => {
+      const document = await collection.findOne({
+        $or: [
+          { _id: ObjectId.createFromHexString(id) },
+          { _id: id }
+        ]
+      });
+
+      if (!document) {
+        return null;
+      }
+
+      return this.createInstance(document);
+    });
+  }
+
+  /**
    * Returns the first model matching the query options.
    *
    * @internal


### PR DESCRIPTION
IDs in MongoDB can be stored as either strings or Object IDs. This meant that if you created a document
and let Mongo assign an id to it, Esix wouldn't be able to find it as it was only looking for the
hex representation.

With this change, `BaseModel.find(id)` will look for documents with either a matching Object id or
a string representation of it.