### PR TITLE
feat: Sanitize queries to prevent NoSQL injections.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+- feat: Sanitize queries to prevent NoSQL injections.
+
+If a query property is an object, we remove properties where the key starts with
+the `$` character to avoid injections.
+
+This is a breaking change!
+
 ### Added
 
 - feat: Add helpful aggregate functions to the Query Builder.

--- a/src/injection.spec.ts
+++ b/src/injection.spec.ts
@@ -1,0 +1,43 @@
+import { v1 as createUuid } from 'uuid';
+import mongodb from 'mongo-mock';
+
+import { BaseModel } from './';
+import { connectionHandler } from './connection-handler';
+
+mongodb.max_delay = 1;
+
+class User extends BaseModel {
+  public password = '';
+  public username = '';
+}
+
+describe('Injections', () => {
+  beforeEach(() => {
+    Object.assign(process.env, {
+      'DB_ADAPTER': 'mock',
+      'DB_DATABASE': `test-${ createUuid() }`
+    });
+  });
+
+  afterAll(() => {
+    connectionHandler.closeConnections();
+  });
+
+  it('prevents NoSQL injections using an object', async() => {
+    const username = 'Tim';
+    const password = { $ne: 1 };
+
+    await User.create({
+      password: 'secretstuff',
+      username: 'Tim'
+    });
+
+    const user = await User
+      .where('username', username)
+      .where('password', password)
+      .first();
+
+    expect(user).toBeNull();
+  });
+
+});

--- a/src/sanitize.spec.ts
+++ b/src/sanitize.spec.ts
@@ -1,0 +1,42 @@
+import { sanitize } from './sanitize';
+
+describe('sanitize', () => {
+
+  it('handles objects', () => {
+    const query = {
+      password: 'hunter1',
+      username: 'john'
+    };
+
+    expect(sanitize(query)).toEqual({
+      password: 'hunter1',
+      username: 'john'
+    });
+  });
+
+
+  it('removes keys starting with $.', () => {
+    const query = {
+      password: { "$ne" : null },
+      username: { "$ne" : null }
+    };
+
+    expect(sanitize(query)).toEqual({
+      password: {},
+      username: {}
+    });
+  });
+
+  it.each([
+    [ null ],
+    [ undefined ],
+    [ 32 ],
+    [ ['5f0aeaeacff57e3ec676b340', '5f0aefba348289a81889a920'] ],
+    [ 'Hello World' ],
+    [ true ],
+    [ false ]
+  ])('does not modify %p values.', (value) => {
+    expect(sanitize(value)).toEqual(value);
+  });
+
+});

--- a/src/sanitize.ts
+++ b/src/sanitize.ts
@@ -1,0 +1,32 @@
+// Removes keys from object which starts with '$' to help
+// avoid NoSQL injections.
+export function sanitize<T>(input: T): T | T[] {
+  if(!isObject(input)) {
+    return input;
+  }
+
+  if (Array.isArray(input)) {
+    return input.map(value => sanitize(value));
+  }
+
+  const keys = Object.keys(input);
+
+  return keys.reduce((carry, key) => {
+    if (isString(key) && key.startsWith('$')) {
+      return carry;
+    }
+
+    return {
+      ...carry,
+      [key]: sanitize((input as Record<string, any>)[key])
+    }
+  }, {} as T);
+}
+
+function isObject(x: any): x is Record<any, any> {
+  return typeof x === 'object' && x !== null;
+}
+
+function isString(x: any): x is string {
+  return typeof x === 'string' || x instanceof String;
+}


### PR DESCRIPTION
If a query property is an object, we remove properties where the key starts with the `$` character to avoid injections.

This is a breaking change!