### PR TITLE
fix: tier 1 bug fixes and pinning tests

### DIFF
--- a/packages/esix/jest.config.js
+++ b/packages/esix/jest.config.js
@@ -1,5 +1,0 @@
-module.exports = {
-  preset: 'ts-jest',
-  testEnvironment: 'node',
-  modulePathIgnorePatterns: ['<rootDir>/dist/']
-}

--- a/packages/esix/src/aggregates.spec.ts
+++ b/packages/esix/src/aggregates.spec.ts
@@ -165,6 +165,39 @@ describe('Aggregate Functions', () => {
     })
   })
 
+  describe('Empty result behavior', () => {
+    it.each([['max'], ['min'], ['sum'], ['average']] as const)(
+      '%s returns 0 when no records match.',
+      async (method) => {
+        const result = await (
+          ResponseTime.where('statusCode', 999) as any
+        )[method]('value')
+
+        expect(result).toEqual(0)
+      }
+    )
+
+    it('percentile returns 0 when no records match.', async () => {
+      const result = await ResponseTime.where('statusCode', 999).percentile(
+        'value',
+        50
+      )
+
+      expect(result).toEqual(0)
+    })
+  })
+
+  describe('Percentile validation', () => {
+    it.each([[-1], [101], [Number.NaN], [Number.POSITIVE_INFINITY]])(
+      'throws when n is %p.',
+      async (n) => {
+        await expect(
+          ResponseTime.where('statusCode', 200).percentile('value', n)
+        ).rejects.toThrow(/Percentile/)
+      }
+    )
+  })
+
   describe('Percentile', () => {
     it('works without values.', async () => {
       const median = await ResponseTime.where('statusCode', 200).percentile(

--- a/packages/esix/src/base-model.spec.ts
+++ b/packages/esix/src/base-model.spec.ts
@@ -336,6 +336,20 @@ describe('BaseModel', () => {
       expect(book).toBeNull()
     })
 
+    it.each([[''], ['not-hex'], ['zzz']])(
+      'returns null and does not throw for invalid id %p.',
+      async (badId) => {
+        collection.findOne.mockReturnValue(null)
+        vi.mocked(ObjectId.createFromHexString).mockImplementation(() => {
+          throw new Error('not a valid ObjectId')
+        })
+
+        const book = await Book.find(badId)
+
+        expect(book).toBeNull()
+      }
+    )
+
     it('finds a document by id.', async () => {
       vi.mocked(ObjectId.createFromHexString).mockImplementation(
         (hexString: string): ObjectId => new ObjectId(hexString)

--- a/packages/esix/src/base-model.ts
+++ b/packages/esix/src/base-model.ts
@@ -110,7 +110,10 @@ export default class BaseModel {
     })
 
     if (!model) {
-      throw new Error('Failed to create model.')
+      throw new Error(
+        `Failed to create ${this.name} (id: ${String(id)}). ` +
+          `The document was inserted but could not be retrieved afterwards.`
+      )
     }
 
     return model

--- a/packages/esix/src/injection.spec.ts
+++ b/packages/esix/src/injection.spec.ts
@@ -39,4 +39,17 @@ describe('Injections', () => {
 
     expect(user).toBeNull()
   })
+
+  it('neutralizes deeply nested injection passed as where value.', async () => {
+    await User.create({
+      password: 'secretstuff',
+      username: 'Tim'
+    })
+
+    const users = await User.where('username', {
+      nested: { $gt: '' }
+    }).get()
+
+    expect(users).toEqual([])
+  })
 })

--- a/packages/esix/src/query-builder.ts
+++ b/packages/esix/src/query-builder.ts
@@ -254,6 +254,10 @@ export default class QueryBuilder<T extends BaseModel> {
   async max<K extends keyof T>(key: K): Promise<number> {
     const values = await this.pluck(key)
 
+    if (values.length === 0) {
+      return 0
+    }
+
     if (!isNumberArray(values)) {
       throw new Error(
         `All values returned for ${String(key)} are not numbers. Please check your data.`
@@ -270,6 +274,10 @@ export default class QueryBuilder<T extends BaseModel> {
    */
   async min<K extends keyof T>(key: K): Promise<number> {
     const values = await this.pluck(key)
+
+    if (values.length === 0) {
+      return 0
+    }
 
     if (!isNumberArray(values)) {
       throw new Error(
@@ -304,6 +312,12 @@ export default class QueryBuilder<T extends BaseModel> {
    * @param n
    */
   async percentile<K extends keyof T>(key: K, n: number): Promise<number> {
+    if (typeof n !== 'number' || !Number.isFinite(n) || n < 0 || n > 100) {
+      throw new Error(
+        `Percentile n must be a finite number between 0 and 100, received: ${n}`
+      )
+    }
+
     const values = await this.pluck(key)
 
     if (values.length === 0) {
@@ -559,29 +573,39 @@ export default class QueryBuilder<T extends BaseModel> {
 
   private execute(fields?: Fields): Promise<T[]> {
     return this.useCollection(async (collection) => {
-      let cursor = fields
-        ? collection.find(this.query, fields)
-        : collection.find(this.query)
+      try {
+        let cursor = fields
+          ? collection.find(this.query, fields)
+          : collection.find(this.query)
 
-      if (this.queryOrder) {
-        cursor = cursor.sort(this.queryOrder)
+        if (this.queryOrder) {
+          cursor = cursor.sort(this.queryOrder)
+        }
+
+        if (this.queryOffset) {
+          cursor = cursor.skip(this.queryOffset)
+        }
+
+        if (this.queryLimit) {
+          cursor = cursor.limit(this.queryLimit)
+        }
+
+        const documents = await cursor.toArray()
+
+        const records = documents
+          .filter((document) => document)
+          .map((document): T => this.createInstance(document))
+
+        return records
+      } catch (error) {
+        if (isTextIndexMissingError(error, this.query)) {
+          throw new Error(
+            `search() requires a text index on the "${collection.collectionName}" collection. ` +
+              `Create one with db.${collection.collectionName}.createIndex({ "<field>": "text" }).`
+          )
+        }
+        throw error
       }
-
-      if (this.queryOffset) {
-        cursor = cursor.skip(this.queryOffset)
-      }
-
-      if (this.queryLimit) {
-        cursor = cursor.limit(this.queryLimit)
-      }
-
-      const documents = await cursor.toArray()
-
-      const records = documents
-        .filter((document) => document)
-        .map((document): T => this.createInstance(document))
-
-      return records
     })
   }
 
@@ -602,4 +626,16 @@ export default class QueryBuilder<T extends BaseModel> {
 
 function isNumberArray(array: any[]): array is number[] {
   return array.every((item) => typeof item === 'number')
+}
+
+function isTextIndexMissingError(
+  error: unknown,
+  query: { [key: string]: unknown }
+): boolean {
+  if (!('$text' in query)) {
+    return false
+  }
+  const message =
+    error instanceof Error ? error.message : String(error ?? '')
+  return /text index/i.test(message) || /\$text/i.test(message)
 }

--- a/packages/esix/src/query-builder.ts
+++ b/packages/esix/src/query-builder.ts
@@ -601,7 +601,8 @@ export default class QueryBuilder<T extends BaseModel> {
         if (isTextIndexMissingError(error, this.query)) {
           throw new Error(
             `search() requires a text index on the "${collection.collectionName}" collection. ` +
-              `Create one with db.${collection.collectionName}.createIndex({ "<field>": "text" }).`
+              `Create one with db["${collection.collectionName}"].createIndex({ "<field>": "text" }).`,
+            { cause: error }
           )
         }
         throw error
@@ -628,14 +629,29 @@ function isNumberArray(array: any[]): array is number[] {
   return array.every((item) => typeof item === 'number')
 }
 
-function isTextIndexMissingError(
+export function isTextIndexMissingError(
   error: unknown,
   query: { [key: string]: unknown }
 ): boolean {
   if (!('$text' in query)) {
     return false
   }
+
+  const code =
+    error && typeof error === 'object' && 'code' in error
+      ? (error as { code?: unknown }).code
+      : undefined
+  const codeName =
+    error && typeof error === 'object' && 'codeName' in error
+      ? (error as { codeName?: unknown }).codeName
+      : undefined
+
+  if (code === 27 || codeName === 'IndexNotFound') {
+    return true
+  }
+
   const message =
     error instanceof Error ? error.message : String(error ?? '')
-  return /text index/i.test(message) || /\$text/i.test(message)
+
+  return /text index required for \$text query/i.test(message)
 }

--- a/packages/esix/src/sanitize.spec.ts
+++ b/packages/esix/src/sanitize.spec.ts
@@ -38,4 +38,51 @@ describe('sanitize', () => {
   ])('does not modify %p values.', (value) => {
     expect(sanitize(value)).toEqual(value)
   })
+
+  it('strips operators nested under safe keys.', () => {
+    expect(sanitize({ user: { $ne: null } })).toEqual({ user: {} })
+  })
+
+  it('strips operator-only objects inside arrays while keeping safe entries.', () => {
+    expect(sanitize([{ $gt: 0 }, { id: 1 }])).toEqual([{}, { id: 1 }])
+  })
+
+  it.each([
+    ['$gt'],
+    ['$lt'],
+    ['$regex'],
+    ['$where'],
+    ['$function'],
+    ['$expr']
+  ])('strips %s operator at any depth.', (operator) => {
+    const input = {
+      level1: {
+        level2: {
+          [operator]: 'malicious',
+          safe: 'ok'
+        }
+      }
+    }
+
+    expect(sanitize(input)).toEqual({
+      level1: {
+        level2: {
+          safe: 'ok'
+        }
+      }
+    })
+  })
+
+  it('throws when input nesting exceeds the depth limit.', () => {
+    let nested: Record<string, unknown> = {}
+    const root = nested
+
+    for (let i = 0; i < 100; i++) {
+      const next: Record<string, unknown> = {}
+      nested.next = next
+      nested = next
+    }
+
+    expect(() => sanitize(root)).toThrow(/maximum depth/)
+  })
 })

--- a/packages/esix/src/sanitize.ts
+++ b/packages/esix/src/sanitize.ts
@@ -1,12 +1,24 @@
 // Removes keys from object which starts with '$' to help
 // avoid NoSQL injections.
+const MAX_DEPTH = 32
+
 export function sanitize<T>(input: T): T | T[] {
+  return _sanitize(input, 0)
+}
+
+function _sanitize<T>(input: T, depth: number): T | T[] {
+  if (depth > MAX_DEPTH) {
+    throw new Error(
+      `sanitize() exceeded maximum depth of ${MAX_DEPTH}. Input is too deeply nested.`
+    )
+  }
+
   if (!isObject(input)) {
     return input
   }
 
   if (Array.isArray(input)) {
-    return input.map((value) => sanitize(value))
+    return input.map((value) => _sanitize(value, depth + 1))
   }
 
   const keys = Object.keys(input)
@@ -18,7 +30,7 @@ export function sanitize<T>(input: T): T | T[] {
 
     return {
       ...carry,
-      [key]: sanitize((input as Record<string, any>)[key])
+      [key]: _sanitize((input as Record<string, any>)[key], depth + 1)
     }
   }, {} as T)
 }

--- a/packages/esix/src/search-error.spec.ts
+++ b/packages/esix/src/search-error.spec.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest'
+
+import { isTextIndexMissingError } from './query-builder'
+
+describe('isTextIndexMissingError', () => {
+  it('returns false when the query does not use $text.', () => {
+    const error = Object.assign(new Error('text index required for $text query'), {
+      code: 27,
+      codeName: 'IndexNotFound'
+    })
+
+    expect(isTextIndexMissingError(error, { name: 'foo' })).toEqual(false)
+  })
+
+  it('returns true when the error has Mongo code 27.', () => {
+    const error = Object.assign(new Error('something went wrong'), {
+      code: 27,
+      codeName: 'IndexNotFound'
+    })
+
+    expect(isTextIndexMissingError(error, { $text: { $search: 'foo' } })).toEqual(
+      true
+    )
+  })
+
+  it('returns true when the error message names the missing text index.', () => {
+    const error = new Error('text index required for $text query')
+
+    expect(isTextIndexMissingError(error, { $text: { $search: 'foo' } })).toEqual(
+      true
+    )
+  })
+
+  it('returns false for unrelated $text errors so the original error survives.', () => {
+    const error = new Error('something else went wrong while running $text')
+
+    expect(isTextIndexMissingError(error, { $text: { $search: 'foo' } })).toEqual(
+      false
+    )
+  })
+
+  it('handles non-Error throwables without crashing.', () => {
+    expect(
+      isTextIndexMissingError('plain string', { $text: { $search: 'foo' } })
+    ).toEqual(false)
+    expect(isTextIndexMissingError(null, { $text: { $search: 'foo' } })).toEqual(
+      false
+    )
+  })
+})


### PR DESCRIPTION
## Summary

- Returns `0` from `max()`/`min()` when the result set is empty so callers no longer see `±Infinity` from spreading an empty array.
- Validates the `n` argument to `percentile()` and throws a clear error when it is not a finite number between `0` and `100`.
- Wraps `execute()` so text-index queries surface a descriptive error explaining how to create the missing text index.
- Includes the model name and inserted id in the error from `BaseModel.create()` when the post-insert lookup returns null.
- Caps `sanitize()` recursion depth at `32` so pathological inputs cannot blow the call stack.
- Removes the stale `jest.config.js` (the project uses Vitest).

## Tests added

- `sanitize.spec.ts` — nested-injection, parametrised operator-stripping (`\$gt`/`\$lt`/`\$regex`/`\$where`/`\$function`/`\$expr`), and a depth-limit test.
- `injection.spec.ts` — deeply nested injection passed as a `where` value is neutralised.
- `aggregates.spec.ts` — empty-result behaviour for `max`/`min`/`sum`/`average`/`percentile`, and percentile validation.
- `base-model.spec.ts` — `find()` returns `null` for invalid ids without throwing.

## Test plan

- [x] `yarn typecheck`
- [x] `CI=true yarn test` — 135 tests pass