### PR TITLE
refactor: centralise collection naming and tighten Query type

### DIFF
--- a/packages/esix/src/index.ts
+++ b/packages/esix/src/index.ts
@@ -1,7 +1,14 @@
 import BaseModel from './base-model'
 import { ConnectionHandler, connectionHandler } from './connection-handler'
+import { getCollectionName } from './naming'
 import QueryBuilder, { type Query } from './query-builder'
 import { type ObjectType, type Dictionary, type Document } from './types'
 
-export { BaseModel, QueryBuilder, ConnectionHandler, connectionHandler }
+export {
+  BaseModel,
+  ConnectionHandler,
+  QueryBuilder,
+  connectionHandler,
+  getCollectionName
+}
 export type { Query, ObjectType, Dictionary, Document }

--- a/packages/esix/src/naming.spec.ts
+++ b/packages/esix/src/naming.spec.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest'
+
+import { getCollectionName } from './naming'
+
+describe('getCollectionName', () => {
+  it.each([
+    ['User', 'users'],
+    ['BlogPost', 'blog-posts'],
+    ['URL', 'urls'],
+    ['A', 'as'],
+    ['User2', 'user2s'],
+    ['OAuthToken', 'o-auth-tokens']
+  ])('maps %s -> %s', (className, expected) => {
+    expect(getCollectionName(className)).toEqual(expected)
+  })
+})

--- a/packages/esix/src/naming.ts
+++ b/packages/esix/src/naming.ts
@@ -1,0 +1,10 @@
+import * as changeCase from 'change-case'
+import pluralize from 'pluralize'
+
+/**
+ * Returns the canonical MongoDB collection name for a model class name.
+ * Example: `BlogPost` → `blog-posts`.
+ */
+export function getCollectionName(className: string): string {
+  return pluralize(changeCase.kebabCase(className))
+}

--- a/packages/esix/src/query-builder.ts
+++ b/packages/esix/src/query-builder.ts
@@ -1,10 +1,9 @@
-import * as changeCase from 'change-case'
 import { Collection, ObjectId } from 'mongodb'
 import percentile from 'percentile'
-import pluralize from 'pluralize'
 
 import type BaseModel from './base-model'
 import { connectionHandler } from './connection-handler'
+import { getCollectionName } from './naming'
 import { sanitize } from './sanitize'
 import type {
   ComparisonOperator,
@@ -17,17 +16,13 @@ import type {
  * Represents a MongoDB query object with flexible field-value pairs.
  * Used for building database queries with various operators and conditions.
  */
-export type Query = { [index: string]: any }
+export type Query = { [index: string]: unknown }
 
 type Order = { [index: string]: 1 | -1 }
 type Fields = { [index: string]: 1 }
 
 function isString(x: any): x is string {
   return typeof x === 'string'
-}
-
-function normalizeName(className: string): string {
-  return pluralize(changeCase.kebabCase(className))
 }
 
 function normalizeAttributes(originalAttributes: Dictionary): Dictionary {
@@ -448,7 +443,7 @@ export default class QueryBuilder<T extends BaseModel> {
     }
     // Object syntax: where({ status: 'active' })
     else {
-      query = sanitize(queryOrKey)
+      query = sanitize(queryOrKey) as Query
     }
 
     this.query = {
@@ -588,7 +583,7 @@ export default class QueryBuilder<T extends BaseModel> {
   private async useCollection<K>(
     block: (collection: Collection) => Promise<any>
   ): Promise<K> {
-    const collectionName = normalizeName(this.ctor.name)
+    const collectionName = getCollectionName(this.ctor.name)
 
     const connection = await connectionHandler.getConnection()
 


### PR DESCRIPTION
## Summary

- Extracts the PascalCase → kebab-case → plural collection-name logic into a shared `getCollectionName` helper in `naming.ts` so future consumers (change-stream listeners, tooling) can reuse it without duplicating the `change-case` + `pluralize` calls.
- Replaces `QueryBuilder`'s local `normalizeName` with `getCollectionName`.
- Tightens the exported `Query` type from `{ [k: string]: any }` to `{ [k: string]: unknown }` so accidental `any`-leakage shows up in the type checker. The only caller-visible adjustment is a single cast in `where()`'s object-syntax branch.

## Tests added

- `naming.spec.ts` parametrises the canonical mappings: `User → users`, `BlogPost → blog-posts`, `URL → urls`, `A → as`, `User2 → user2s`, `OAuthToken → o-auth-tokens`.

## Test plan

- [x] `yarn typecheck`
- [x] `CI=true yarn test` — 119 tests pass