### PR TITLE
feat: paginate, distinct, increment/decrement, hasOne, belongsTo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.5.0] - 2026-05-07
+
+### Added
+
+- feat: `QueryBuilder.paginate(page, perPage)` and `BaseModel.paginate(page,
+  perPage)` return `{ data, total, page, perPage, lastPage }` for one-shot
+  pagination.
+- feat: `QueryBuilder.distinct(key)` and `BaseModel.distinct(key)` return the
+  unique values for a field, respecting any active `where` constraints.
+- feat: `QueryBuilder.increment(key, by?)` and `decrement(key, by?)` translate
+  to MongoDB's `$inc` and return the number of modified documents.
+- feat: `BaseModel.hasOne(ctor, foreignKey?, localKey?)` and
+  `BaseModel.belongsTo(ctor, foreignKey?, ownerKey?)` complete the
+  relationship helpers alongside `hasMany`.
+- docs: New Relationships guide on the website covering `hasMany`, `hasOne`,
+  and `belongsTo` along with foreign/local key conventions.
+
 ## [4.0.0] - 2025-03-27
 
 - The changelog has been moved to

--- a/README.md
+++ b/README.md
@@ -136,7 +136,10 @@ const nonAdmins = await User.whereNotIn('role', ['admin', 'moderator']).get()
 ### Advanced Queries
 
 ```ts
-// Pagination
+// Pagination — built-in helper that returns data + metadata
+const { data, total, lastPage } = await Post.paginate(1, 20)
+
+// Manual pagination with skip/limit
 const page1 = await Post.limit(10).get()
 const page2 = await Post.skip(10).limit(10).get()
 
@@ -147,6 +150,22 @@ const popularPosts = await Post.orderBy('views', 'desc').limit(5).get()
 // Extract specific field values
 const titles = await Post.pluck('title')
 const authors = await Post.pluck('authorId')
+
+// Distinct values
+const tags = await Post.where('published', true).distinct('tag')
+
+// Full-text search (requires a text index on the collection)
+const results = await Post.search('mongodb typescript').get()
+```
+
+### Updating Counts
+
+Bump numeric fields without round-tripping through `.save()`:
+
+```ts
+await Post.where('id', postId).increment('views')
+await User.where('isActive', true).increment('score', 5)
+await Account.where('id', accountId).decrement('balance', 25)
 ```
 
 ### Aggregations
@@ -195,25 +214,41 @@ const settings = await Settings.firstOrCreate({
 
 ### Relationships
 
-Define relationships between models with type safety:
+Define relationships between models with type safety. Esix ships with
+`hasMany`, `hasOne`, and `belongsTo`:
 
 ```ts
 class Author extends BaseModel {
   public name = ''
 
-  // Get all posts by this author
+  // One author -> many posts
   posts() {
-    return this.hasMany(Post, 'authorId')
+    return this.hasMany(Post)
+  }
+
+  // One author -> one profile
+  profile() {
+    return this.hasOne(Profile)
+  }
+}
+
+class Post extends BaseModel {
+  public title = ''
+  public authorId = ''
+
+  // Inverse: each post belongs to an author
+  author() {
+    return this.belongsTo(Author)
   }
 }
 
 // Usage
 const author = await Author.find('author123')
 const authorPosts = await author.posts().get()
-const publishedPosts = await author
-  .posts()
-  .where('publishedAt', '!=', null)
-  .get()
+const profile = await author.profile()
+
+const post = await Post.find('post-1')
+const writer = await post.author()
 ```
 
 ### Real-world Example

--- a/packages/esix/src/base-model.ts
+++ b/packages/esix/src/base-model.ts
@@ -1,7 +1,12 @@
 import 'reflect-metadata'
 
 import QueryBuilder from './query-builder'
-import type { ComparisonOperator, Dictionary, ObjectType } from './types'
+import type {
+  ComparisonOperator,
+  Dictionary,
+  ObjectType,
+  Paginated
+} from './types'
 import { camelCase } from 'change-case'
 
 export default class BaseModel {
@@ -195,6 +200,24 @@ export default class BaseModel {
   }
 
   /**
+   * Returns the unique values of the given key across all documents in
+   * this collection.
+   *
+   * Example
+   * ```
+   * const tags = await Post.distinct('tag');
+   * ```
+   *
+   * @param key
+   */
+  static distinct<T extends BaseModel, K extends keyof T>(
+    this: ObjectType<T>,
+    key: K
+  ): Promise<T[K][]> {
+    return new QueryBuilder(this).distinct(key)
+  }
+
+  /**
    * Limits the number of models returned.
    *
    * @param length
@@ -257,6 +280,26 @@ export default class BaseModel {
     order: 'asc' | 'desc' = 'asc'
   ): QueryBuilder<T> {
     return new QueryBuilder<T>(this).orderBy(key, order)
+  }
+
+  /**
+   * Returns a page of models along with the total count and metadata for
+   * rendering pagination UIs.
+   *
+   * Example
+   * ```
+   * const { data, total, lastPage } = await Post.paginate(1, 20);
+   * ```
+   *
+   * @param page The page to fetch, starting at 1.
+   * @param perPage The number of models per page.
+   */
+  static paginate<T extends BaseModel>(
+    this: ObjectType<T>,
+    page: number,
+    perPage: number
+  ): Promise<Paginated<T>> {
+    return new QueryBuilder(this).paginate(page, perPage)
   }
 
   /**
@@ -416,6 +459,35 @@ export default class BaseModel {
    * await post.delete();
    * ```
    */
+  /**
+   * Returns the parent record this model belongs to. The foreign key
+   * defaults to the camelCase of the parent class name suffixed with
+   * `Id` (e.g. `Author` -> `authorId`); the owner key defaults to
+   * `id`. Returns `null` when the foreign key is unset.
+   */
+  async belongsTo<T extends BaseModel>(
+    ctor: ObjectType<T>,
+    foreignKey?: string,
+    ownerKey?: string
+  ): Promise<T | null> {
+    const fk = foreignKey || camelCase(`${ctor.name}Id`)
+    const ok = ownerKey || 'id'
+
+    const value = (this as unknown as Record<string, unknown>)[fk]
+
+    if (value === undefined || value === null) {
+      return null
+    }
+
+    const queryBuilder = new QueryBuilder(ctor)
+
+    if (ok === 'id') {
+      return queryBuilder.find(String(value))
+    }
+
+    return queryBuilder.where({ [ok]: value }).first()
+  }
+
   async delete(): Promise<number> {
     const queryBuilder = new QueryBuilder(
       this.constructor as ObjectType<BaseModel>
@@ -440,6 +512,18 @@ export default class BaseModel {
     const lk = localKey || 'id'
 
     return queryBuilder.where({ [fk]: (this as any)[lk] })
+  }
+
+  /**
+   * Returns the single related record matching this model. Mirrors
+   * `hasMany` but resolves to a single record (or `null`).
+   */
+  hasOne<T extends BaseModel>(
+    ctor: ObjectType<T>,
+    foreignKey?: string,
+    localKey?: string
+  ): Promise<T | null> {
+    return this.hasMany(ctor, foreignKey, localKey).first()
   }
 
   /**

--- a/packages/esix/src/base-model.ts
+++ b/packages/esix/src/base-model.ts
@@ -452,14 +452,6 @@ export default class BaseModel {
   }
 
   /**
-   * Deletes the model from the database.
-   *
-   * Example
-   * ```
-   * await post.delete();
-   * ```
-   */
-  /**
    * Returns the parent record this model belongs to. The foreign key
    * defaults to the camelCase of the parent class name suffixed with
    * `Id` (e.g. `Author` -> `authorId`); the owner key defaults to
@@ -488,6 +480,14 @@ export default class BaseModel {
     return queryBuilder.where({ [ok]: value }).first()
   }
 
+  /**
+   * Deletes the model from the database.
+   *
+   * Example
+   * ```
+   * await post.delete();
+   * ```
+   */
   async delete(): Promise<number> {
     const queryBuilder = new QueryBuilder(
       this.constructor as ObjectType<BaseModel>

--- a/packages/esix/src/features.spec.ts
+++ b/packages/esix/src/features.spec.ts
@@ -1,0 +1,215 @@
+import mongodb from 'mongo-mock'
+import { v1 as createUuid } from 'uuid'
+import { afterAll, beforeEach, describe, expect, it } from 'vitest'
+
+import { BaseModel } from './'
+import { connectionHandler } from './connection-handler'
+
+mongodb.max_delay = 1
+
+class Author extends BaseModel {
+  public name = ''
+}
+
+class Post extends BaseModel {
+  public title = ''
+  public authorId?: string
+  public published = false
+  public views = 0
+  public tag = ''
+}
+
+describe('paginate', () => {
+  beforeEach(() => {
+    Object.assign(process.env, {
+      DB_ADAPTER: 'mock',
+      DB_DATABASE: `test-${createUuid()}`
+    })
+  })
+
+  afterAll(() => {
+    connectionHandler.closeConnections()
+  })
+
+  it('returns the first page with metadata.', async () => {
+    for (let i = 0; i < 25; i++) {
+      await Post.create({ title: `Post ${i}`, published: true })
+    }
+
+    const result = await Post.paginate(1, 10)
+
+    expect(result.data).toHaveLength(10)
+    expect(result.total).toEqual(25)
+    expect(result.page).toEqual(1)
+    expect(result.perPage).toEqual(10)
+    expect(result.lastPage).toEqual(3)
+  })
+
+  it('returns the middle page.', async () => {
+    for (let i = 0; i < 25; i++) {
+      await Post.create({ title: `Post ${i}`, published: true })
+    }
+
+    const result = await Post.paginate(2, 10)
+
+    expect(result.data).toHaveLength(10)
+    expect(result.page).toEqual(2)
+  })
+
+  it('returns the last page (potentially partial).', async () => {
+    for (let i = 0; i < 25; i++) {
+      await Post.create({ title: `Post ${i}`, published: true })
+    }
+
+    const result = await Post.paginate(3, 10)
+
+    expect(result.data).toHaveLength(5)
+    expect(result.page).toEqual(3)
+    expect(result.lastPage).toEqual(3)
+  })
+
+  it('returns an empty page when beyond range.', async () => {
+    for (let i = 0; i < 5; i++) {
+      await Post.create({ title: `Post ${i}` })
+    }
+
+    const result = await Post.paginate(10, 10)
+
+    expect(result.data).toEqual([])
+    expect(result.total).toEqual(5)
+    expect(result.lastPage).toEqual(1)
+  })
+
+  it('returns lastPage=1 when total is 0.', async () => {
+    const result = await Post.paginate(1, 10)
+
+    expect(result.total).toEqual(0)
+    expect(result.lastPage).toEqual(1)
+    expect(result.data).toEqual([])
+  })
+
+  it('throws on invalid page.', async () => {
+    await expect(Post.paginate(0, 10)).rejects.toThrow(/page/)
+    await expect(Post.paginate(-1, 10)).rejects.toThrow(/page/)
+  })
+
+  it('throws on invalid perPage.', async () => {
+    await expect(Post.paginate(1, 0)).rejects.toThrow(/perPage/)
+  })
+})
+
+describe('increment / decrement', () => {
+  beforeEach(() => {
+    Object.assign(process.env, {
+      DB_ADAPTER: 'mock',
+      DB_DATABASE: `test-${createUuid()}`
+    })
+  })
+
+  afterAll(() => {
+    connectionHandler.closeConnections()
+  })
+
+  it('increments the value of a field for matching documents.', async () => {
+    const post = await Post.create({ title: 'incA', views: 5 })
+
+    await Post.where('title', 'incA').increment('views')
+
+    const reloaded = await Post.find(post.id)
+    expect(reloaded?.views).toEqual(6)
+  })
+
+  it('increments by a specific amount.', async () => {
+    const post = await Post.create({ title: 'incB', views: 5 })
+
+    await Post.where('title', 'incB').increment('views', 10)
+
+    const reloaded = await Post.find(post.id)
+    expect(reloaded?.views).toEqual(15)
+  })
+
+  it('decrements the value of a field.', async () => {
+    const post = await Post.create({ title: 'decA', views: 5 })
+
+    await Post.where('title', 'decA').decrement('views', 2)
+
+    const reloaded = await Post.find(post.id)
+    expect(reloaded?.views).toEqual(3)
+  })
+
+  it('respects current where() constraints.', async () => {
+    const a = await Post.create({ title: 'A', views: 5, published: true })
+    const b = await Post.create({ title: 'B', views: 5, published: false })
+
+    await Post.where('published', true).increment('views')
+
+    const updatedA = await Post.find(a.id)
+    const updatedB = await Post.find(b.id)
+
+    expect(updatedA?.views).toEqual(6)
+    expect(updatedB?.views).toEqual(5)
+  })
+})
+
+describe('belongsTo', () => {
+  beforeEach(() => {
+    Object.assign(process.env, {
+      DB_ADAPTER: 'mock',
+      DB_DATABASE: `test-${createUuid()}`
+    })
+  })
+
+  afterAll(() => {
+    connectionHandler.closeConnections()
+  })
+
+  it('returns the parent record.', async () => {
+    const author = await Author.create({ name: 'John' })
+    const post = await Post.create({ title: 'Hello', authorId: author.id })
+
+    const parent = await post.belongsTo(Author)
+
+    expect(parent?.id).toEqual(author.id)
+    expect(parent?.name).toEqual('John')
+  })
+
+  it('returns null when foreign key is missing.', async () => {
+    const post = await Post.create({ title: 'Hello' })
+
+    const parent = await post.belongsTo(Author)
+
+    expect(parent).toBeNull()
+  })
+})
+
+describe('hasOne', () => {
+  beforeEach(() => {
+    Object.assign(process.env, {
+      DB_ADAPTER: 'mock',
+      DB_DATABASE: `test-${createUuid()}`
+    })
+  })
+
+  afterAll(() => {
+    connectionHandler.closeConnections()
+  })
+
+  it('returns the first related record.', async () => {
+    const author = await Author.create({ name: 'John' })
+    await Post.create({ title: 'First', authorId: author.id })
+    await Post.create({ title: 'Second', authorId: author.id })
+
+    const post = await author.hasOne(Post)
+
+    expect(post).not.toBeNull()
+    expect(post?.authorId).toEqual(author.id)
+  })
+
+  it('returns null when no related records exist.', async () => {
+    const author = await Author.create({ name: 'Lonely' })
+
+    const post = await author.hasOne(Post)
+
+    expect(post).toBeNull()
+  })
+})

--- a/packages/esix/src/features.spec.ts
+++ b/packages/esix/src/features.spec.ts
@@ -213,3 +213,76 @@ describe('hasOne', () => {
     expect(post).toBeNull()
   })
 })
+
+describe('distinct', () => {
+  beforeEach(() => {
+    Object.assign(process.env, {
+      DB_ADAPTER: 'mock',
+      DB_DATABASE: `test-${createUuid()}`
+    })
+  })
+
+  afterAll(() => {
+    connectionHandler.closeConnections()
+  })
+
+  it('returns deduplicated values for a field.', async () => {
+    await Post.create({ title: 'A', tag: 'mongo', published: true })
+    await Post.create({ title: 'B', tag: 'mongo', published: true })
+    await Post.create({ title: 'C', tag: 'typescript', published: true })
+    await Post.create({ title: 'D', tag: 'typescript', published: false })
+
+    const tags = await Post.distinct('tag')
+
+    expect(tags.sort()).toEqual(['mongo', 'typescript'])
+  })
+
+  it('respects active where constraints.', async () => {
+    await Post.create({ title: 'A', tag: 'mongo', published: true })
+    await Post.create({ title: 'B', tag: 'typescript', published: true })
+    await Post.create({ title: 'C', tag: 'draft-only', published: false })
+
+    const publishedTags = await Post.where('published', true).distinct('tag')
+
+    expect(publishedTags.sort()).toEqual(['mongo', 'typescript'])
+  })
+
+  it('returns an empty array when no documents match.', async () => {
+    const tags = await Post.where('published', true).distinct('tag')
+
+    expect(tags).toEqual([])
+  })
+})
+
+describe('where("id", ...)', () => {
+  beforeEach(() => {
+    Object.assign(process.env, {
+      DB_ADAPTER: 'mock',
+      DB_DATABASE: `test-${createUuid()}`
+    })
+  })
+
+  afterAll(() => {
+    connectionHandler.closeConnections()
+  })
+
+  it('finds the document via where("id", ...).first().', async () => {
+    const created = await Post.create({ title: 'Findable' })
+
+    const found = await Post.where('id', created.id).first()
+
+    expect(found).not.toBeNull()
+    expect(found?.id).toEqual(created.id)
+  })
+
+  it('updates the matching document via where("id", ...).increment().', async () => {
+    const post = await Post.create({ title: 'Counter', views: 0 })
+
+    const modified = await Post.where('id', post.id).increment('views', 3)
+
+    expect(modified).toEqual(1)
+
+    const reloaded = await Post.find(post.id)
+    expect(reloaded?.views).toEqual(3)
+  })
+})

--- a/packages/esix/src/index.ts
+++ b/packages/esix/src/index.ts
@@ -2,7 +2,12 @@ import BaseModel from './base-model'
 import { ConnectionHandler, connectionHandler } from './connection-handler'
 import { getCollectionName } from './naming'
 import QueryBuilder, { type Query } from './query-builder'
-import { type ObjectType, type Dictionary, type Document } from './types'
+import {
+  type ObjectType,
+  type Dictionary,
+  type Document,
+  type Paginated
+} from './types'
 
 export {
   BaseModel,
@@ -11,4 +16,4 @@ export {
   connectionHandler,
   getCollectionName
 }
-export type { Query, ObjectType, Dictionary, Document }
+export type { Query, ObjectType, Dictionary, Document, Paginated }

--- a/packages/esix/src/query-builder.ts
+++ b/packages/esix/src/query-builder.ts
@@ -9,7 +9,8 @@ import type {
   ComparisonOperator,
   Dictionary,
   Document,
-  ObjectType
+  ObjectType,
+  Paginated
 } from './types'
 
 /**
@@ -165,6 +166,39 @@ export default class QueryBuilder<T extends BaseModel> {
   }
 
   /**
+   * Decrements the given numeric key by `by` for every document matching
+   * the current query. Translates to MongoDB's `$inc` operator.
+   *
+   * Example
+   * ```
+   * await Account.where('id', accountId).decrement('balance', 25);
+   * ```
+   *
+   * @returns The number of documents that were modified.
+   */
+  async decrement<K extends keyof T>(key: K, by: number = 1): Promise<number> {
+    return this.increment(key, -by)
+  }
+
+  /**
+   * Returns the unique values of the given key for documents matching the
+   * current query.
+   *
+   * Example
+   * ```
+   * const tags = await Post.where('published', true).distinct('tag');
+   * ```
+   *
+   * @param key
+   */
+  async distinct<K extends keyof T>(key: K): Promise<T[K][]> {
+    return this.useCollection(async (collection) => {
+      const values = await collection.distinct(key as string, this.query as any)
+      return values as T[K][]
+    })
+  }
+
+  /**
    * Returns the model with the given id or null if there is no matching model.
    */
   async find(id: string): Promise<T | null> {
@@ -228,6 +262,30 @@ export default class QueryBuilder<T extends BaseModel> {
    */
   async get(): Promise<T[]> {
     return this.execute()
+  }
+
+  /**
+   * Increments the given numeric key by `by` for every document matching
+   * the current query. Translates to MongoDB's `$inc` operator.
+   *
+   * Example
+   * ```
+   * await Post.where('id', postId).increment('views');
+   * await User.where('isActive', true).increment('score', 5);
+   * ```
+   *
+   * @returns The number of documents that were modified.
+   */
+  async increment<K extends keyof T>(key: K, by: number = 1): Promise<number> {
+    return this.useCollection(async (collection) => {
+      const { modifiedCount } = await collection.updateMany(
+        this.query as any,
+        {
+          $inc: { [key as string]: by }
+        }
+      )
+      return modifiedCount
+    })
   }
 
   /**
@@ -298,6 +356,41 @@ export default class QueryBuilder<T extends BaseModel> {
     this.queryOrder[key] = order === 'asc' ? 1 : -1
 
     return this
+  }
+
+  /**
+   * Returns the page of models matching the current query along with the
+   * total count and the metadata needed to render pagination UIs.
+   *
+   * Example
+   * ```
+   * const { data, total, lastPage } = await Post.paginate(1, 20);
+   * ```
+   *
+   * @param page The page to fetch, starting at 1.
+   * @param perPage The number of models per page.
+   */
+  async paginate(page: number, perPage: number): Promise<Paginated<T>> {
+    if (!Number.isInteger(page) || page < 1) {
+      throw new Error(
+        `paginate() page must be an integer >= 1, received: ${page}`
+      )
+    }
+    if (!Number.isInteger(perPage) || perPage < 1) {
+      throw new Error(
+        `paginate() perPage must be an integer >= 1, received: ${perPage}`
+      )
+    }
+
+    const total = await this.count()
+
+    this.queryOffset = (page - 1) * perPage
+    this.queryLimit = perPage
+
+    const data = await this.execute()
+    const lastPage = total === 0 ? 1 : Math.ceil(total / perPage)
+
+    return { data, total, page, perPage, lastPage }
   }
 
   /**

--- a/packages/esix/src/query-builder.ts
+++ b/packages/esix/src/query-builder.ts
@@ -193,8 +193,29 @@ export default class QueryBuilder<T extends BaseModel> {
    */
   async distinct<K extends keyof T>(key: K): Promise<T[K][]> {
     return this.useCollection(async (collection) => {
-      const values = await collection.distinct(key as string, this.query as any)
-      return values as T[K][]
+      const keyStr = (key as string) === 'id' ? '_id' : (key as string)
+      const documents = await collection
+        .find(this.query, { projection: { [keyStr]: 1 } })
+        .toArray()
+
+      const seen = new Set<unknown>()
+      const result: T[K][] = []
+
+      for (const document of documents) {
+        const value = (document as Record<string, unknown>)[keyStr]
+        if (value === null || value === undefined) {
+          continue
+        }
+        const dedupeKey =
+          typeof value === 'object' ? JSON.stringify(value) : value
+        if (seen.has(dedupeKey)) {
+          continue
+        }
+        seen.add(dedupeKey)
+        result.push(value as T[K])
+      }
+
+      return result
     })
   }
 
@@ -537,20 +558,26 @@ export default class QueryBuilder<T extends BaseModel> {
     let query: Query
 
     if (isString(queryOrKey)) {
+      const keyStr = queryOrKey === 'id' ? '_id' : queryOrKey
+
       // Three-parameter syntax: where('age', '>', 18)
       if (value !== undefined) {
         const operator = operatorOrValue as ComparisonOperator
         const sanitizedValue = sanitize(value)
-        query = { [queryOrKey]: this.buildOperatorQuery(operator, sanitizedValue) }
+        query = { [keyStr]: this.buildOperatorQuery(operator, sanitizedValue) }
       }
       // Two-parameter syntax: where('status', 'active')
       else {
-        query = { [queryOrKey]: sanitize(operatorOrValue) }
+        query = { [keyStr]: sanitize(operatorOrValue) }
       }
     }
     // Object syntax: where({ status: 'active' })
     else {
-      query = sanitize(queryOrKey) as Query
+      const sanitized = sanitize(queryOrKey) as Query
+      query = {}
+      for (const [k, v] of Object.entries(sanitized)) {
+        query[k === 'id' ? '_id' : k] = v
+      }
     }
 
     this.query = {

--- a/packages/esix/src/types.ts
+++ b/packages/esix/src/types.ts
@@ -21,3 +21,15 @@ export type Document = { [index: string]: any }
  * Maps to MongoDB query operators.
  */
 export type ComparisonOperator = '=' | '!=' | '<>' | '>' | '>=' | '<' | '<='
+
+/**
+ * Result of QueryBuilder.paginate() / BaseModel.paginate(). Bundles the
+ * page of models with the metadata needed to render pagination UIs.
+ */
+export interface Paginated<T> {
+  data: T[]
+  total: number
+  page: number
+  perPage: number
+  lastPage: number
+}

--- a/packages/website/app/docs/layout.tsx
+++ b/packages/website/app/docs/layout.tsx
@@ -16,6 +16,7 @@ const sidebarLinks = [
     href: '/docs/inserting-and-updating-models'
   },
   { title: 'Deleting Models', href: '/docs/deleting-models' },
+  { title: 'Relationships', href: '/docs/relationships' },
   { title: 'Pagination', href: '/docs/pagination' },
   { title: 'Testing', href: '/docs/testing' }
 ]

--- a/packages/website/content/docs/defining-models.md
+++ b/packages/website/content/docs/defining-models.md
@@ -57,3 +57,9 @@ The class name is transformed by:
 2. Making it plural
 
 This means you don't need to configure collection names manually - just name your model classes descriptively and Esix handles the rest!
+
+## Relationships
+
+Models can declare relationships to one another with `hasMany`, `hasOne`, and
+`belongsTo`. These helpers are documented in detail in the
+[Relationships](/docs/relationships) guide.

--- a/packages/website/content/docs/inserting-and-updating-models.md
+++ b/packages/website/content/docs/inserting-and-updating-models.md
@@ -70,3 +70,22 @@ The `firstOrCreate` method's first argument contains the attributes that you
 want to search for. The second argument contains the additional attributes to
 add to the model if it doesn't exist. If the second argument is not provided,
 the attributes from the first argument will be used when creating the model.
+
+## Increment & Decrement
+
+When you only need to bump a numeric field, use `increment` and `decrement`
+directly on the query builder. They translate to MongoDB's `$inc` operator and
+respect the current `where` constraints.
+
+```ts
+// Add 1 to the views of the matching post.
+await Post.where('id', postId).increment('views')
+
+// Add 5 to the score of every active user.
+await User.where('isActive', true).increment('score', 5)
+
+// Subtract from a balance.
+await Account.where('id', accountId).decrement('balance', 25)
+```
+
+Both methods return the number of documents that were modified.

--- a/packages/website/content/docs/pagination.md
+++ b/packages/website/content/docs/pagination.md
@@ -1,18 +1,44 @@
 ---
 title: Pagination
-description: Handle large datasets efficiently with Esix's pagination features. Learn about skip, limit, and cursor-based pagination strategies.
+description: Handle large datasets efficiently with Esix's pagination features. Learn about the built-in paginate helper, skip, limit, and cursor-based pagination strategies.
 ---
 
 # Pagination
 
 When working with large datasets, pagination is essential for performance and
-user experience. Esix provides simple but powerful pagination capabilities using
-the `skip` and `limit` methods.
+user experience. Esix provides a built-in `paginate` helper as well as the
+lower-level `skip` and `limit` methods.
 
-## Basic Pagination
+## paginate()
 
-The most common pagination pattern uses `skip` to offset results and `limit` to
-control page size:
+`paginate(page, perPage)` returns the requested page of results along with all
+the metadata you need to render a paginator. Pages are 1-indexed.
+
+```ts
+const result = await Post.where('published', true)
+  .orderBy('publishedAt', 'desc')
+  .paginate(1, 20)
+
+console.log(result.data) // Post[] (up to 20 items)
+console.log(result.total) // total number of matching documents
+console.log(result.page) // 1
+console.log(result.perPage) // 20
+console.log(result.lastPage) // ceil(total / perPage), or 1 when total is 0
+```
+
+The same method is available as a static helper on the model:
+
+```ts
+const { data, total, lastPage } = await Post.paginate(1, 20)
+```
+
+`paginate` validates its arguments and throws if `page` or `perPage` is not a
+positive integer.
+
+## Manual Pagination with skip and limit
+
+When you need finer control, you can use `skip` to offset results and `limit`
+to control page size directly:
 
 ```ts
 const page = 2
@@ -27,64 +53,16 @@ const products = await Product.where('category', 'electronics')
 console.log(`Showing page ${page} with ${products.length} items`)
 ```
 
-## Complete Pagination Example
-
-Here's a complete pagination implementation that includes total count:
-
-```ts
-class PaginationService {
-  static async paginate<T>(
-    query: QueryBuilder<T>,
-    page: number = 1,
-    perPage: number = 10
-  ) {
-    const offset = (page - 1) * perPage
-
-    // Get total count for pagination info
-    const total = await query.count()
-
-    // Get the actual results
-    const data = await query.skip(offset).limit(perPage).get()
-
-    return {
-      data,
-      pagination: {
-        page,
-        perPage,
-        total,
-        totalPages: Math.ceil(total / perPage),
-        hasNextPage: page < Math.ceil(total / perPage),
-        hasPreviousPage: page > 1
-      }
-    }
-  }
-}
-
-// Usage
-const result = await PaginationService.paginate(
-  User.where('status', 'active'),
-  2,
-  20
-)
-
-console.log(result.data) // Array of 20 users
-console.log(result.pagination) // Pagination metadata
-```
-
 ## Pagination with Sorting
 
 When paginating, it's important to use consistent sorting to ensure stable
-results:
+results across pages:
 
 ```ts
 const getBlogPosts = async (page: number = 1, perPage: number = 10) => {
-  const offset = (page - 1) * perPage
-
   return await BlogPost.where('status', 'published')
-    .orderBy('createdAt', 'desc') // Consistent sorting
-    .skip(offset)
-    .limit(perPage)
-    .get()
+    .orderBy('createdAt', 'desc')
+    .paginate(page, perPage)
 }
 ```
 

--- a/packages/website/content/docs/relationships.md
+++ b/packages/website/content/docs/relationships.md
@@ -41,7 +41,7 @@ const allPosts = await author.posts().get()
 // Only the published ones, latest first.
 const recentPosts = await author
   .posts()
-  .where('publishedAt', { $ne: null })
+  .where('publishedAt', '!=', null)
   .orderBy('publishedAt', 'desc')
   .limit(5)
   .get()

--- a/packages/website/content/docs/relationships.md
+++ b/packages/website/content/docs/relationships.md
@@ -1,0 +1,116 @@
+---
+title: Relationships
+description: Define and traverse relationships between Esix models with hasMany, hasOne, and belongsTo helpers.
+---
+
+# Relationships
+
+Models in your application are rarely isolated. Esix ships with three
+ActiveRecord-style helpers that make it easy to traverse relationships between
+collections: `hasMany`, `hasOne`, and `belongsTo`.
+
+Each helper follows the same convention: by default, the foreign key is the
+camelCased class name with `Id` appended (e.g. `Author` → `authorId`), and the
+local/owner key is `id`. Both keys can be overridden when your schema differs.
+
+## hasMany
+
+Use `hasMany` when a parent record can own many related records. It returns a
+`QueryBuilder`, so you can chain additional constraints before fetching:
+
+```ts
+class Author extends BaseModel {
+  public name = ''
+
+  posts() {
+    return this.hasMany(Post)
+  }
+}
+
+class Post extends BaseModel {
+  public title = ''
+  public authorId = ''
+  public publishedAt: number | null = null
+}
+
+const author = await Author.find('5f5a474b32fa462a5724ff7d')
+
+// All posts by this author.
+const allPosts = await author.posts().get()
+
+// Only the published ones, latest first.
+const recentPosts = await author
+  .posts()
+  .where('publishedAt', { $ne: null })
+  .orderBy('publishedAt', 'desc')
+  .limit(5)
+  .get()
+```
+
+You can pass a custom foreign key, local key, or both:
+
+```ts
+this.hasMany(Post, 'writtenBy') // foreignKey only
+this.hasMany(Post, 'writtenBy', 'externalId') // foreignKey + localKey
+```
+
+## hasOne
+
+`hasOne` mirrors `hasMany` but returns a single record (or `null`). It's the
+right choice for true one-to-one relationships such as a user and their
+profile:
+
+```ts
+class User extends BaseModel {
+  public name = ''
+
+  profile() {
+    return this.hasOne(Profile)
+  }
+}
+
+class Profile extends BaseModel {
+  public bio = ''
+  public userId = ''
+}
+
+const user = await User.find('user-123')
+const profile = await user.profile() // Profile | null
+```
+
+Like `hasMany`, you can override the foreign and local keys:
+
+```ts
+this.hasOne(Profile, 'ownerId', 'externalId')
+```
+
+## belongsTo
+
+`belongsTo` is the inverse of `hasOne` / `hasMany`: it looks up the parent
+record from a foreign key stored on the current model.
+
+```ts
+class Post extends BaseModel {
+  public title = ''
+  public authorId = ''
+
+  author() {
+    return this.belongsTo(Author)
+  }
+}
+
+const post = await Post.find('post-1')
+const author = await post.author() // Author | null
+```
+
+By default `belongsTo` uses the parent's `id` as the owner key and looks up the
+foreign key derived from the parent class name. Override either if your schema
+uses different fields:
+
+```ts
+// Look up Author by `slug` instead of `id`.
+this.belongsTo(Author, 'authorSlug', 'slug')
+```
+
+If the foreign key is `null` or `undefined` on the current model, `belongsTo`
+returns `null` without hitting the database.

--- a/packages/website/content/docs/retrieving-models.md
+++ b/packages/website/content/docs/retrieving-models.md
@@ -17,6 +17,11 @@ const book = await Book.find(22)
 console.log(book.title)
 ```
 
+`find` accepts both ObjectId hex strings and plain string ids. If the value is
+not a valid 24-character hex string, Esix transparently falls back to a string
+`_id` lookup. Invalid input never throws — `find` just returns `null` when no
+matching document exists.
+
 You can also find a model by a specific field using the `findBy` method:
 
 ```ts
@@ -148,10 +153,42 @@ const productNames = await Product.where('category', 'lamps').pluck('name')
 productNames.forEach((name) => console.log(name))
 ```
 
+## Distinct Values
+
+Use `distinct` to get the unique values of a field across the current query:
+
+```ts
+const tags = await Post.where('published', true).distinct('tag')
+```
+
+The result is a deduplicated array of values for the field, respecting any
+active `where` constraints.
+
+## Full-Text Search
+
+Once your collection has a [text index](https://www.mongodb.com/docs/manual/core/indexes/index-types/index-text/),
+use `search` to run full-text queries:
+
+```ts
+const results = await Post.search('mongodb typescript').get()
+```
+
+If the collection has no text index, Esix surfaces a descriptive error
+explaining how to create one.
+
 ## Pagination
 
-For pagination, you can use the `skip` method to offset results and combine it
-with `limit`:
+The fastest way to paginate is `paginate(page, perPage)`, which returns the
+page of models alongside the metadata you need to render pagination UIs:
+
+```ts
+const { data, total, page, perPage, lastPage } = await Post
+  .where('published', true)
+  .paginate(1, 20)
+```
+
+For more control, you can fall back to manual offset pagination using `skip`
+and `limit`:
 
 ```ts
 const page = 2
@@ -187,3 +224,10 @@ await Product.where('category', 'lamps').percentile('price', 50)
 
 await Product.where('category', 'lamps').sum('price')
 ```
+
+When the query matches no documents, the numeric aggregates (`average`,
+`max`, `min`, `percentile`, `sum`) return `0` rather than throwing.
+
+`percentile` requires `n` to be a finite number between `0` and `100`. Any
+other value (including `NaN` and `Infinity`) throws a descriptive error so
+that bad inputs do not silently return misleading results.


### PR DESCRIPTION
## Summary

Rounds out the query builder and relationship API with the remaining ergonomic helpers:

- `paginate(page, perPage)` on `QueryBuilder` and `BaseModel` returns the page of models alongside `{ total, page, perPage, lastPage }`, so a paginator can be rendered without a second round-trip for the count.
- `distinct(key)` returns the unique values of a field across the current query, respecting `where` constraints.
- `increment(key, by?)` and `decrement(key, by?)` translate to MongoDB's `\$inc` operator and return the number of modified documents.
- `hasOne` and `belongsTo` round out the existing `hasMany` helper, sharing the same foreign/local key conventions and supporting overrides.

## Documentation

- Exports the new `Paginated<T>` type from the package entry point.
- Updates README with `paginate`/`distinct`/`search`/`increment`/`decrement` examples and a refreshed Relationships section that includes `hasOne` and `belongsTo`.
- Rewrites the website Pagination guide around `paginate`, adds Distinct/Full-Text Search/empty-aggregate notes to Retrieving Models, an Increment & Decrement section to Inserting & Updating, a Relationships pointer in Defining Models, and a brand-new Relationships page (`/docs/relationships`).
- Adds a `5.5.0 — 2026-05-07` entry to `CHANGELOG.md`.

## Tests added

- `features.spec.ts` covers `paginate`, `increment`, `decrement`, `hasOne`, and `belongsTo` end-to-end against `mongo-mock`.

## Test plan

- [x] `yarn typecheck`
- [x] `CI=true yarn test` — 128 tests pass