### PR TITLE
feat: add whereNull, whereNotNull and orWhere query operators

### DIFF
--- a/packages/esix/src/base-model.ts
+++ b/packages/esix/src/base-model.ts
@@ -452,6 +452,47 @@ export default class BaseModel {
   }
 
   /**
+   * Returns models where `key` is present and not `null`. Documents where
+   * the field is `null` or missing entirely are excluded.
+   *
+   * Example
+   * ```
+   * const enrichedBooks = await Book.whereNotNull('openLibraryEnrichedVersion').get();
+   * ```
+   *
+   * @param key - A property of the model
+   */
+  static whereNotNull<T extends BaseModel, K extends keyof T>(
+    this: ObjectType<T>,
+    key: K
+  ): QueryBuilder<T> {
+    const queryBuilder = new QueryBuilder(this)
+
+    return queryBuilder.whereNotNull(key)
+  }
+
+  /**
+   * Returns models where `key` is `null`. Following MongoDB's null-equality
+   * semantics, this matches documents where the field is `null` OR missing
+   * entirely.
+   *
+   * Example
+   * ```
+   * const unenrichedBooks = await Book.whereNull('openLibraryEnrichedVersion').get();
+   * ```
+   *
+   * @param key - A property of the model
+   */
+  static whereNull<T extends BaseModel, K extends keyof T>(
+    this: ObjectType<T>,
+    key: K
+  ): QueryBuilder<T> {
+    const queryBuilder = new QueryBuilder(this)
+
+    return queryBuilder.whereNull(key)
+  }
+
+  /**
    * Returns the parent record this model belongs to. The foreign key
    * defaults to the camelCase of the parent class name suffixed with
    * `Id` (e.g. `Author` -> `authorId`); the owner key defaults to

--- a/packages/esix/src/query-builder.ts
+++ b/packages/esix/src/query-builder.ts
@@ -52,6 +52,7 @@ function normalizeAttributes(originalAttributes: Dictionary): Dictionary {
 export default class QueryBuilder<T extends BaseModel> {
   private readonly ctor: ObjectType<T>
 
+  private orQueries: Query[] = []
   private query: Query = {}
 
   private queryLimit?: number
@@ -109,9 +110,11 @@ export default class QueryBuilder<T extends BaseModel> {
    * ```
    */
   async count(): Promise<number> {
+    const query = this.buildQuery()
+
     const count = await this.useCollection<number>(
       (collection): Promise<number> => {
-        return collection.count(this.query)
+        return collection.count(query)
       }
     )
 
@@ -192,10 +195,12 @@ export default class QueryBuilder<T extends BaseModel> {
    * @param key
    */
   async distinct<K extends keyof T>(key: K): Promise<T[K][]> {
+    const query = this.buildQuery()
+
     return this.useCollection(async (collection) => {
       const keyStr = (key as string) === 'id' ? '_id' : (key as string)
       const documents = await collection
-        .find(this.query, { projection: { [keyStr]: 1 } })
+        .find(query, { projection: { [keyStr]: 1 } })
         .toArray()
 
       const seen = new Set<unknown>()
@@ -298,8 +303,10 @@ export default class QueryBuilder<T extends BaseModel> {
    * @returns The number of documents that were modified.
    */
   async increment<K extends keyof T>(key: K, by: number = 1): Promise<number> {
+    const query = this.buildQuery()
+
     return this.useCollection(async (collection) => {
-      const { modifiedCount } = await collection.updateMany(this.query as any, {
+      const { modifiedCount } = await collection.updateMany(query as any, {
         $inc: { [key as string]: by }
       })
       return modifiedCount
@@ -372,6 +379,62 @@ export default class QueryBuilder<T extends BaseModel> {
     }
 
     this.queryOrder[key] = order === 'asc' ? 1 : -1
+
+    return this
+  }
+
+  /**
+   * Adds a constraint that is combined with the previous constraints using
+   * a logical OR. Accepts the same arguments as `where`.
+   *
+   * Subsequent `where` calls are ANDed into the most recent OR group, so
+   * AND binds tighter than OR: `where(a).orWhere(b).where(c)` selects
+   * documents matching `a OR (b AND c)`.
+   *
+   * When called without any previous constraints, `orWhere` behaves exactly
+   * like `where`. There is no static `orWhere` on `BaseModel` since an OR
+   * condition is meaningless without a preceding constraint — start the
+   * chain with `where`, `whereNull`, or one of the other query methods.
+   *
+   * Note: `orWhere` cannot be combined with `search()`.
+   *
+   * Example
+   * ```
+   * const books = await Book.whereNull('openLibraryEnrichedVersion')
+   *   .orWhere('openLibraryEnrichedVersion', '<', 3)
+   *   .get();
+   * ```
+   *
+   * @param query - A query object to filter by
+   * @param key - Property name to filter by (must be a valid model field)
+   * @param operatorOrValue - Comparison operator or value when using 2-param syntax
+   * @param value - The value to filter by when using 3-param syntax with operator
+   */
+  orWhere(query: Query): QueryBuilder<T>
+  orWhere<K extends keyof T>(key: K, value: T[K]): QueryBuilder<T>
+  orWhere<K extends keyof T>(
+    key: K,
+    operator: ComparisonOperator,
+    value: T[K]
+  ): QueryBuilder<T>
+  orWhere(
+    queryOrKey: Query | string,
+    operatorOrValue?: ComparisonOperator | any,
+    value?: any
+  ): QueryBuilder<T> {
+    const condition = this.buildConditionQuery(
+      queryOrKey,
+      operatorOrValue,
+      value
+    )
+
+    if (Object.keys(this.query).length === 0 && this.orQueries.length === 0) {
+      this.query = condition
+
+      return this
+    }
+
+    this.orQueries.push(condition)
 
     return this
   }
@@ -552,35 +615,13 @@ export default class QueryBuilder<T extends BaseModel> {
     operatorOrValue?: ComparisonOperator | any,
     value?: any
   ): QueryBuilder<T> {
-    let query: Query
+    const condition = this.buildConditionQuery(
+      queryOrKey,
+      operatorOrValue,
+      value
+    )
 
-    if (isString(queryOrKey)) {
-      const keyStr = queryOrKey === 'id' ? '_id' : queryOrKey
-
-      // Three-parameter syntax: where('age', '>', 18)
-      if (value !== undefined) {
-        const operator = operatorOrValue as ComparisonOperator
-        const sanitizedValue = sanitize(value)
-        query = { [keyStr]: this.buildOperatorQuery(operator, sanitizedValue) }
-      }
-      // Two-parameter syntax: where('status', 'active')
-      else {
-        query = { [keyStr]: sanitize(operatorOrValue) }
-      }
-    }
-    // Object syntax: where({ status: 'active' })
-    else {
-      const sanitized = sanitize(queryOrKey) as Query
-      query = {}
-      for (const [k, v] of Object.entries(sanitized)) {
-        query[k === 'id' ? '_id' : k] = v
-      }
-    }
-
-    this.query = {
-      ...this.query,
-      ...query
-    }
+    this.mergeCondition(condition)
 
     return this
   }
@@ -625,16 +666,11 @@ export default class QueryBuilder<T extends BaseModel> {
   whereIn(key: string, values: any[]): QueryBuilder<T> {
     const keyStr = key === 'id' ? '_id' : key
 
-    const query = {
+    this.mergeCondition({
       [keyStr]: {
         $in: sanitize(values)
       }
-    }
-
-    this.query = {
-      ...this.query,
-      ...query
-    }
+    })
 
     return this
   }
@@ -649,18 +685,116 @@ export default class QueryBuilder<T extends BaseModel> {
   whereNotIn(key: string, values: any[]): QueryBuilder<T> {
     const keyStr = key === 'id' ? '_id' : key
 
-    const query = {
+    this.mergeCondition({
       [keyStr]: {
         $nin: sanitize(values)
       }
-    }
-
-    this.query = {
-      ...this.query,
-      ...query
-    }
+    })
 
     return this
+  }
+
+  /**
+   * Returns all the models where `key` is present and not `null`.
+   * Translates to MongoDB's `$ne` operator, so documents where the field
+   * is `null` or missing entirely are excluded.
+   *
+   * Example
+   * ```
+   * const enrichedBooks = await Book.whereNotNull('openLibraryEnrichedVersion').get();
+   * ```
+   *
+   * @param key - A property of the model
+   */
+  whereNotNull<K extends keyof T>(key: K): QueryBuilder<T> {
+    const keyStr = (key as string) === 'id' ? '_id' : (key as string)
+
+    this.mergeCondition({
+      [keyStr]: {
+        $ne: null
+      }
+    })
+
+    return this
+  }
+
+  /**
+   * Returns all the models where `key` is `null`. Following MongoDB's
+   * null-equality semantics, this matches documents where the field is
+   * `null` OR missing entirely.
+   *
+   * Example
+   * ```
+   * const unenrichedBooks = await Book.whereNull('openLibraryEnrichedVersion').get();
+   * ```
+   *
+   * @param key - A property of the model
+   */
+  whereNull<K extends keyof T>(key: K): QueryBuilder<T> {
+    const keyStr = (key as string) === 'id' ? '_id' : (key as string)
+
+    this.mergeCondition({
+      [keyStr]: null
+    })
+
+    return this
+  }
+
+  /**
+   * Builds a single condition object from the arguments accepted by
+   * `where` and `orWhere`, remapping `id` to `_id` and sanitizing values.
+   *
+   * @param queryOrKey - A query object or a property name
+   * @param operatorOrValue - Comparison operator or value when using 2-param syntax
+   * @param value - The value to filter by when using 3-param syntax with operator
+   */
+  private buildConditionQuery(
+    queryOrKey: Query | string,
+    operatorOrValue?: ComparisonOperator | any,
+    value?: any
+  ): Query {
+    let query: Query
+
+    if (isString(queryOrKey)) {
+      const keyStr = queryOrKey === 'id' ? '_id' : queryOrKey
+
+      // Three-parameter syntax: where('age', '>', 18)
+      if (value !== undefined) {
+        const operator = operatorOrValue as ComparisonOperator
+        const sanitizedValue = sanitize(value)
+        query = { [keyStr]: this.buildOperatorQuery(operator, sanitizedValue) }
+      }
+      // Two-parameter syntax: where('status', 'active')
+      else {
+        query = { [keyStr]: sanitize(operatorOrValue) }
+      }
+    }
+    // Object syntax: where({ status: 'active' })
+    else {
+      const sanitized = sanitize(queryOrKey) as Query
+      query = {}
+      for (const [k, v] of Object.entries(sanitized)) {
+        query[k === 'id' ? '_id' : k] = v
+      }
+    }
+
+    return query
+  }
+
+  /**
+   * Builds the final query object, combining the base query with any OR
+   * groups added through `orWhere`.
+   */
+  private buildQuery(): Query {
+    if (this.orQueries.length === 0) {
+      return this.query
+    }
+
+    if ('$text' in this.query) {
+      throw new Error('search() cannot be combined with orWhere().')
+    }
+
+    return { $or: [this.query, ...this.orQueries] }
   }
 
   private createInstance<T>(document: Document): T {
@@ -684,11 +818,13 @@ export default class QueryBuilder<T extends BaseModel> {
   }
 
   private execute(fields?: Fields): Promise<T[]> {
+    const query = this.buildQuery()
+
     return this.useCollection(async (collection) => {
       try {
         let cursor = fields
-          ? collection.find(this.query, fields)
-          : collection.find(this.query)
+          ? collection.find(query, fields)
+          : collection.find(query)
 
         if (this.queryOrder) {
           cursor = cursor.sort(this.queryOrder)
@@ -710,7 +846,7 @@ export default class QueryBuilder<T extends BaseModel> {
 
         return records
       } catch (error) {
-        if (isTextIndexMissingError(error, this.query)) {
+        if (isTextIndexMissingError(error, query)) {
           throw new Error(
             `search() requires a text index on the "${collection.collectionName}" collection. ` +
               `Create one with db["${collection.collectionName}"].createIndex({ "<field>": "text" }).`,
@@ -720,6 +856,31 @@ export default class QueryBuilder<T extends BaseModel> {
         throw error
       }
     })
+  }
+
+  /**
+   * Merges a condition into the current query group. Conditions are ANDed
+   * into the most recent OR group when one exists, so AND binds tighter
+   * than OR.
+   *
+   * @param condition
+   */
+  private mergeCondition(condition: Query): void {
+    if (this.orQueries.length > 0) {
+      const lastIndex = this.orQueries.length - 1
+
+      this.orQueries[lastIndex] = {
+        ...this.orQueries[lastIndex],
+        ...condition
+      }
+
+      return
+    }
+
+    this.query = {
+      ...this.query,
+      ...condition
+    }
   }
 
   private async useCollection<K>(

--- a/packages/esix/src/query-builder.ts
+++ b/packages/esix/src/query-builder.ts
@@ -385,16 +385,20 @@ export default class QueryBuilder<T extends BaseModel> {
 
   /**
    * Adds a constraint that is combined with the previous constraints using
-   * a logical OR. Accepts the same arguments as `where`.
+   * a logical OR. Mirrors `where`'s call forms; values are typed against
+   * the model's properties.
    *
    * Subsequent `where` calls are ANDed into the most recent OR group, so
    * AND binds tighter than OR: `where(a).orWhere(b).where(c)` selects
    * documents matching `a OR (b AND c)`.
    *
    * When called without any previous constraints, `orWhere` behaves exactly
-   * like `where`. There is no static `orWhere` on `BaseModel` since an OR
-   * condition is meaningless without a preceding constraint — start the
-   * chain with `where`, `whereNull`, or one of the other query methods.
+   * like `where`. Conditions that are empty after sanitization (for example
+   * `{ $where: ... }`, which is stripped to `{}`) are ignored rather than
+   * added as an OR branch, matching the no-op semantics of `where({})`.
+   * There is no static `orWhere` on `BaseModel` since an OR condition is
+   * meaningless without a preceding constraint — start the chain with
+   * `where`, `whereNull`, or one of the other query methods.
    *
    * Note: `orWhere` cannot be combined with `search()`.
    *
@@ -427,6 +431,10 @@ export default class QueryBuilder<T extends BaseModel> {
       operatorOrValue,
       value
     )
+
+    if (Object.keys(condition).length === 0) {
+      return this
+    }
 
     if (Object.keys(this.query).length === 0 && this.orQueries.length === 0) {
       this.query = condition

--- a/packages/esix/src/query-operators.spec.ts
+++ b/packages/esix/src/query-operators.spec.ts
@@ -1,0 +1,206 @@
+import mongodb from 'mongo-mock'
+import { v1 as createUuid } from 'uuid'
+import { afterAll, beforeEach, describe, expect, it } from 'vitest'
+
+import { BaseModel } from './'
+import { connectionHandler } from './connection-handler'
+import QueryBuilder from './query-builder'
+
+mongodb.max_delay = 1
+
+class Book extends BaseModel {
+  public openLibraryEnrichedVersion: number | null = null
+  public title = ''
+}
+
+describe('whereNull', () => {
+  beforeEach(() => {
+    Object.assign(process.env, {
+      DB_ADAPTER: 'mock',
+      DB_DATABASE: `test-${createUuid()}`
+    })
+  })
+
+  afterAll(() => {
+    connectionHandler.closeConnections()
+  })
+
+  it('matches documents where the field is null.', async () => {
+    await Book.create({ title: 'Null Book', openLibraryEnrichedVersion: null })
+    await Book.create({ title: 'Enriched Book', openLibraryEnrichedVersion: 2 })
+
+    const books = await Book.whereNull('openLibraryEnrichedVersion').get()
+
+    expect(books.map((book) => book.title)).toEqual(['Null Book'])
+  })
+
+  it('matches documents where the field is missing.', async () => {
+    await new QueryBuilder(Book).create({ title: 'Missing Field Book' })
+    await Book.create({ title: 'Enriched Book', openLibraryEnrichedVersion: 2 })
+
+    const books = await Book.whereNull('openLibraryEnrichedVersion').get()
+
+    expect(books.map((book) => book.title)).toEqual(['Missing Field Book'])
+  })
+})
+
+describe('whereNotNull', () => {
+  beforeEach(() => {
+    Object.assign(process.env, {
+      DB_ADAPTER: 'mock',
+      DB_DATABASE: `test-${createUuid()}`
+    })
+  })
+
+  afterAll(() => {
+    connectionHandler.closeConnections()
+  })
+
+  it('excludes documents where the field is null or missing.', async () => {
+    await Book.create({ title: 'Null Book', openLibraryEnrichedVersion: null })
+    await new QueryBuilder(Book).create({ title: 'Missing Field Book' })
+    await Book.create({ title: 'Enriched Book', openLibraryEnrichedVersion: 2 })
+
+    const books = await Book.whereNotNull('openLibraryEnrichedVersion').get()
+
+    expect(books.map((book) => book.title)).toEqual(['Enriched Book'])
+  })
+})
+
+describe('orWhere', () => {
+  beforeEach(() => {
+    Object.assign(process.env, {
+      DB_ADAPTER: 'mock',
+      DB_DATABASE: `test-${createUuid()}`
+    })
+  })
+
+  afterAll(() => {
+    connectionHandler.closeConnections()
+  })
+
+  it('selects documents where the field is null or below a version.', async () => {
+    await Book.create({
+      title: 'Never Enriched',
+      openLibraryEnrichedVersion: null
+    })
+    await Book.create({ title: 'Stale', openLibraryEnrichedVersion: 2 })
+    await Book.create({ title: 'Current', openLibraryEnrichedVersion: 3 })
+
+    const books = await Book.whereNull('openLibraryEnrichedVersion')
+      .orWhere('openLibraryEnrichedVersion', '<', 3)
+      .get()
+
+    expect(books.map((book) => book.title).sort()).toEqual([
+      'Never Enriched',
+      'Stale'
+    ])
+  })
+
+  it('binds AND tighter than OR.', async () => {
+    await Book.create({ title: 'First Group', openLibraryEnrichedVersion: 1 })
+    await Book.create({ title: 'B And C', openLibraryEnrichedVersion: 5 })
+    await Book.create({ title: 'B Only', openLibraryEnrichedVersion: 5 })
+
+    // a OR (b AND c)
+    const books = await Book.where('openLibraryEnrichedVersion', 1)
+      .orWhere('openLibraryEnrichedVersion', 5)
+      .where('title', 'B And C')
+      .get()
+
+    expect(books.map((book) => book.title).sort()).toEqual([
+      'B And C',
+      'First Group'
+    ])
+  })
+
+  it('behaves like where when used as the first condition.', async () => {
+    await Book.create({ title: 'Solo' })
+    await Book.create({ title: 'Other' })
+
+    const books = await new QueryBuilder(Book).orWhere('title', 'Solo').get()
+
+    expect(books.map((book) => book.title)).toEqual(['Solo'])
+  })
+
+  it('supports chaining multiple orWhere calls.', async () => {
+    await Book.create({ title: 'A' })
+    await Book.create({ title: 'B' })
+    await Book.create({ title: 'C' })
+    await Book.create({ title: 'D' })
+
+    const books = await Book.where('title', 'A')
+      .orWhere('title', 'B')
+      .orWhere('title', 'C')
+      .get()
+
+    expect(books.map((book) => book.title).sort()).toEqual(['A', 'B', 'C'])
+  })
+
+  it('supports count with an orWhere chain.', async () => {
+    await Book.create({
+      title: 'Never Enriched',
+      openLibraryEnrichedVersion: null
+    })
+    await Book.create({ title: 'Stale', openLibraryEnrichedVersion: 2 })
+    await Book.create({ title: 'Current', openLibraryEnrichedVersion: 3 })
+
+    const count = await Book.whereNull('openLibraryEnrichedVersion')
+      .orWhere('openLibraryEnrichedVersion', '<', 3)
+      .count()
+
+    expect(count).toEqual(2)
+  })
+
+  it('supports delete with an orWhere chain.', async () => {
+    await Book.create({
+      title: 'Never Enriched',
+      openLibraryEnrichedVersion: null
+    })
+    await Book.create({ title: 'Stale', openLibraryEnrichedVersion: 2 })
+    await Book.create({ title: 'Current', openLibraryEnrichedVersion: 3 })
+
+    const deletedCount = await Book.whereNull('openLibraryEnrichedVersion')
+      .orWhere('openLibraryEnrichedVersion', '<', 3)
+      .delete()
+
+    expect(deletedCount).toEqual(2)
+
+    const remainingBooks = await Book.all()
+
+    expect(remainingBooks.map((book) => book.title)).toEqual(['Current'])
+  })
+
+  it('remaps id to _id.', async () => {
+    const target = await Book.create({ title: 'Target' })
+    await Book.create({ title: 'Other' })
+
+    const books = await Book.where('title', 'No Such Title')
+      .orWhere('id', target.id)
+      .get()
+
+    expect(books).toHaveLength(1)
+    expect(books[0].id).toEqual(target.id)
+  })
+
+  it('strips operator objects passed as values.', async () => {
+    await Book.create({ title: 'Real Book' })
+
+    const books = await new QueryBuilder(Book)
+      .orWhere('title', { $gt: '' } as any)
+      .get()
+
+    expect(books).toEqual([])
+  })
+
+  it('rejects when combined with search().', async () => {
+    await Book.create({ title: 'Searchable' })
+
+    await expect(
+      new QueryBuilder(Book)
+        .search('Searchable')
+        .orWhere('title', 'Searchable')
+        .get()
+    ).rejects.toThrow('search() cannot be combined with orWhere().')
+  })
+})

--- a/packages/esix/src/query-operators.spec.ts
+++ b/packages/esix/src/query-operators.spec.ts
@@ -193,6 +193,86 @@ describe('orWhere', () => {
     expect(books).toEqual([])
   })
 
+  it('ignores object conditions that sanitize down to nothing.', async () => {
+    await Book.create({ title: 'A' })
+    await Book.create({ title: 'B' })
+
+    const books = await Book.where('title', 'A')
+      .orWhere({ $where: 'sleep(100) || true' } as any)
+      .get()
+
+    expect(books.map((book) => book.title)).toEqual(['A'])
+  })
+
+  it('ignores an empty object condition in the middle of a chain.', async () => {
+    await Book.create({ title: 'A' })
+    await Book.create({ title: 'B' })
+    await Book.create({ title: 'C' })
+
+    const books = await Book.where('title', 'A')
+      .orWhere('title', 'B')
+      .orWhere({})
+      .get()
+
+    expect(books.map((book) => book.title).sort()).toEqual(['A', 'B'])
+  })
+
+  it('ignores an empty object condition as the first call.', async () => {
+    await Book.create({ title: 'A' })
+    await Book.create({ title: 'B' })
+
+    const books = await new QueryBuilder(Book).orWhere({}).get()
+
+    expect(books.map((book) => book.title).sort()).toEqual(['A', 'B'])
+  })
+
+  it('supports paginate with an orWhere chain.', async () => {
+    await Book.create({
+      title: 'Never Enriched',
+      openLibraryEnrichedVersion: null
+    })
+    await Book.create({ title: 'Stale 1', openLibraryEnrichedVersion: 1 })
+    await Book.create({ title: 'Stale 2', openLibraryEnrichedVersion: 2 })
+    await Book.create({ title: 'Current 1', openLibraryEnrichedVersion: 9 })
+    await Book.create({ title: 'Current 2', openLibraryEnrichedVersion: 9 })
+
+    const result = await Book.whereNull('openLibraryEnrichedVersion')
+      .orWhere('openLibraryEnrichedVersion', '<', 3)
+      .paginate(1, 2)
+
+    expect(result.data).toHaveLength(2)
+    expect(result.total).toEqual(3)
+    expect(result.page).toEqual(1)
+    expect(result.lastPage).toEqual(2)
+  })
+
+  it('supports first with orderBy and an orWhere chain.', async () => {
+    await Book.create({ title: 'A', openLibraryEnrichedVersion: 1 })
+    await Book.create({ title: 'B', openLibraryEnrichedVersion: 2 })
+    await Book.create({ title: 'C', openLibraryEnrichedVersion: 9 })
+
+    const book = await Book.where('openLibraryEnrichedVersion', 1)
+      .orWhere('openLibraryEnrichedVersion', 2)
+      .orderBy('openLibraryEnrichedVersion', 'desc')
+      .first()
+
+    expect(book?.title).toEqual('B')
+  })
+
+  it('merges whereIn into the most recent OR group.', async () => {
+    await Book.create({ title: 'A', openLibraryEnrichedVersion: 1 })
+    await Book.create({ title: 'B', openLibraryEnrichedVersion: 5 })
+    await Book.create({ title: 'D', openLibraryEnrichedVersion: 5 })
+
+    // a OR (b AND in)
+    const books = await Book.where('title', 'A')
+      .orWhere('openLibraryEnrichedVersion', 5)
+      .whereIn('title', ['B', 'C'])
+      .get()
+
+    expect(books.map((book) => book.title).sort()).toEqual(['A', 'B'])
+  })
+
   it('rejects when combined with search().', async () => {
     await Book.create({ title: 'Searchable' })
 
@@ -200,6 +280,18 @@ describe('orWhere', () => {
       new QueryBuilder(Book)
         .search('Searchable')
         .orWhere('title', 'Searchable')
+        .get()
+    ).rejects.toThrow('search() cannot be combined with orWhere().')
+  })
+
+  it('rejects when search() is called after orWhere().', async () => {
+    await Book.create({ title: 'Searchable' })
+
+    await expect(
+      new QueryBuilder(Book)
+        .where('title', 'A')
+        .orWhere('title', 'B')
+        .search('Searchable')
         .get()
     ).rejects.toThrow('search() cannot be combined with orWhere().')
   })

--- a/packages/website/docs/retrieving-models.md
+++ b/packages/website/docs/retrieving-models.md
@@ -182,6 +182,72 @@ const popularPosts = await BlogPost
 
 Note: The two-parameter syntax `where('status', 'published')` is still supported for equality comparisons and remains the recommended approach for simple equality checks.
 
+## Null Checks
+
+Use `whereNull` to retrieve models where a field is `null`. Following
+MongoDB's null-equality semantics, this also matches documents where the field
+is missing entirely:
+
+```ts
+const unenrichedBooks = await Book.whereNull('openLibraryEnrichedVersion').get()
+```
+
+| id                         | title             | openLibraryEnrichedVersion |
+|----------------------------|-------------------|----------------------------|
+| `5f5a474b32fa462a5724ff7d` | `Never Enriched`  | `null`                     |
+| `5f5a474b32fa462a5724ff7e` | `Imported Legacy` | *(missing)*                |
+
+Conversely, `whereNotNull` retrieves models where a field is present and not
+`null`. Documents where the field is `null` or missing are excluded:
+
+```ts
+const enrichedBooks = await Book.whereNotNull('openLibraryEnrichedVersion').get()
+```
+
+| id                         | title                  | openLibraryEnrichedVersion |
+|----------------------------|------------------------|----------------------------|
+| `5f5a474b32fa462a5724ff7f` | `Effective TypeScript` | `2`                        |
+| `5f5a474b32fa462a5724ff80` | `Domain-Driven Design` | `3`                        |
+
+## Or Conditions
+
+By default, chained conditions are combined with a logical AND. Use `orWhere`
+to combine conditions with a logical OR instead. It accepts the same arguments
+as `where`, including comparison operators, so you can express selections like
+"null or below a version" without loading the whole collection:
+
+```ts
+const staleBooks = await Book.whereNull('openLibraryEnrichedVersion')
+  .orWhere('openLibraryEnrichedVersion', '<', 3)
+  .get()
+```
+
+| id                         | title                  | openLibraryEnrichedVersion |
+|----------------------------|------------------------|----------------------------|
+| `5f5a474b32fa462a5724ff7d` | `Never Enriched`       | `null`                     |
+| `5f5a474b32fa462a5724ff7f` | `Effective TypeScript` | `2`                        |
+
+AND binds tighter than OR, just like in SQL. Any `where` calls following an
+`orWhere` are ANDed into the most recent OR group, so
+`where(a).orWhere(b).where(c)` selects documents matching `a OR (b AND c)`:
+
+```ts
+// status is 'draft', OR (status is 'published' AND views > 1000)
+const posts = await BlogPost.where('status', 'draft')
+  .orWhere('status', 'published')
+  .where('views', '>', 1000)
+  .get()
+```
+
+| id                         | title                             | status      | views  |
+|----------------------------|-----------------------------------|-------------|--------|
+| `601198119f1b2c4d8e7f3a09` | `Unfinished Ideas`                | `draft`     |      0 |
+| `6011a52b9f1b2c4d8e7f3a21` | `Introducing Aggregate Functions` | `published` | 12_840 |
+
+`orWhere` is only available on the Query Builder, so start your chain with
+`where`, `whereNull`, or another query method. Note that `orWhere` cannot be
+combined with `search()`.
+
 ## Array Queries
 
 You can use `whereIn` to retrieve models where a column's value is within a


### PR DESCRIPTION
Implements #67: typed null checks and OR support on the QueryBuilder, so selections like "field is null OR field < n" work against both the mongodb and mock adapters without loading the whole collection.

- **`whereNull(key)`** matches documents where the field is `null` **or missing entirely** (MongoDB null-equality semantics). **`whereNotNull(key)`** translates to `$ne: null` and excludes both. Both are available statically on `BaseModel` and on the builder.
- **`orWhere(...)`** mirrors `where()`'s three call forms (query object, key/value, key/operator/value; values typed against the model's properties) and starts a new OR group. Subsequent `where`/`whereIn`/`whereNotIn`/`whereNull`/`whereNotNull` calls are ANDed into the most recent group, so **AND binds tighter than OR** (SQL/Laravel precedence): `where(a).orWhere(b).where(c)` → `a OR (b AND c)`. As the first condition, `orWhere` degrades to a plain `where`.
- **No static `BaseModel.orWhere`** — an OR condition is meaningless without a preceding constraint, so chains start with `where`, `whereNull`, etc.
- All query consumers (`get`, `first`, `count`, `distinct`, `increment`/`decrement`, `pluck`, `delete`, `paginate`, aggregates) build the final `$or` query through a pure `buildQuery()`.

### Fail-closed empty-condition handling

`sanitize()` strips `$`-prefixed keys, so an injection payload like `orWhere({ $where: ... })` sanitizes down to `{}`. An empty OR branch would match **everything** and strictly widen the selection, so `orWhere` ignores conditions that are empty after sanitization — matching the no-op semantics of `where({})`. Pinned by tests.

### search() incompatibility

`$text` is illegal inside `$or`, so combining `search()` with `orWhere()` (in either call order) throws `search() cannot be combined with orWhere().` instead of producing an invalid query.

### Docs

`packages/website/docs/retrieving-models.md` gains "Null Checks" and "Or Conditions" sections documenting the null-or-missing semantics and the AND/OR precedence, in the page's existing prose + code + example-output style.

## Merge order

- Merge **after** #68 (`feat/68-typed-query-values`) — both touch the `where` overload block in `query-builder.ts`. When rebasing this branch onto #68, `orWhere`'s value types should adopt #68's `QueryValue<T[K]>` helper for consistency with the tightened `where()`.
- The #70 PR (`feat/70-chunk-cursor`) adds a `fetchBatch` that reads `this.query` directly — whichever of #67/#70 merges second must route it through `buildQuery()` so chunk/cursor respect orWhere groups.

## Testing

- 19 new integration tests in `query-operators.spec.ts` (mongo-mock), covering null/missing matching, the issue's exact selection, precedence, OR groups with `count`/`delete`/`paginate`/`first`/`whereIn`, `id` remapping, injection safety, empty-condition no-ops, and the `search()` guard in both call orders.
- Full suite: 185/185 passing; `yarn lint`, `yarn typecheck`, `yarn build` (root), and `yarn build` (website, mintlify broken-links) all green.

Closes #67
