### PR TITLE
feat: type where, whereIn and whereNotIn values as T[K]

### DIFF
--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -1,0 +1,20 @@
+name: Typecheck
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [20.x, 22.x, 23.x]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: yarn
+      - run: yarn typecheck

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,7 +137,7 @@ const results = await User.aggregate([
 ])
 
 // Chaining with query methods
-const avgAgeForAdults = await User.where('age', { $gte: 18 }).average('age')
+const avgAgeForAdults = await User.where('age', '>=', 18).average('age')
 ```
 
 ## Documentation

--- a/packages/esix/src/base-model.ts
+++ b/packages/esix/src/base-model.ts
@@ -380,18 +380,18 @@ export default class BaseModel {
    *
    * @param key - A property of the model
    * @param operatorOrValue - Comparison operator or value when using 2-param syntax
-   * @param value - The value when using 3-param syntax with operator
+   * @param value - The value to filter by, type-checked against the model's property type
    */
   static where<T extends BaseModel, K extends keyof T>(
     this: ObjectType<T>,
     key: K,
-    value: any
+    value: T[K]
   ): QueryBuilder<T>
   static where<T extends BaseModel, K extends keyof T>(
     this: ObjectType<T>,
     key: K,
     operator: ComparisonOperator,
-    value: any
+    value: T[K]
   ): QueryBuilder<T>
   static where<T extends BaseModel, K extends keyof T>(
     this: ObjectType<T>,
@@ -418,12 +418,12 @@ export default class BaseModel {
    * ```
    *
    * @param key - A property of the model
-   * @param values
+   * @param values - The values to match, type-checked against the model's property type
    */
   static whereIn<T extends BaseModel, K extends keyof T>(
     this: ObjectType<T>,
     key: K,
-    values: any[]
+    values: T[K][]
   ): QueryBuilder<T> {
     const queryBuilder = new QueryBuilder(this)
 
@@ -439,12 +439,12 @@ export default class BaseModel {
    * ```
    *
    * @param key - A property of the model
-   * @param values
+   * @param values - The values to exclude, type-checked against the model's property type
    */
   static whereNotIn<T extends BaseModel, K extends keyof T>(
     this: ObjectType<T>,
     key: K,
-    values: any[]
+    values: T[K][]
   ): QueryBuilder<T> {
     const queryBuilder = new QueryBuilder(this)
 

--- a/packages/esix/src/base-model.ts
+++ b/packages/esix/src/base-model.ts
@@ -5,7 +5,8 @@ import type {
   ComparisonOperator,
   Dictionary,
   ObjectType,
-  Paginated
+  Paginated,
+  QueryValue
 } from './types'
 import { camelCase } from 'change-case'
 
@@ -380,18 +381,19 @@ export default class BaseModel {
    *
    * @param key - A property of the model
    * @param operatorOrValue - Comparison operator or value when using 2-param syntax
-   * @param value - The value to filter by, type-checked against the model's property type
+   * @param value - The value to filter by, type-checked against the model's
+   *   property type. Array fields also accept their element type.
    */
   static where<T extends BaseModel, K extends keyof T>(
     this: ObjectType<T>,
     key: K,
-    value: T[K]
+    value: QueryValue<T[K]>
   ): QueryBuilder<T>
   static where<T extends BaseModel, K extends keyof T>(
     this: ObjectType<T>,
     key: K,
     operator: ComparisonOperator,
-    value: T[K]
+    value: QueryValue<T[K]>
   ): QueryBuilder<T>
   static where<T extends BaseModel, K extends keyof T>(
     this: ObjectType<T>,
@@ -418,12 +420,13 @@ export default class BaseModel {
    * ```
    *
    * @param key - A property of the model
-   * @param values - The values to match, type-checked against the model's property type
+   * @param values - The values to match, type-checked against the model's
+   *   property type. Array fields also accept their element type.
    */
   static whereIn<T extends BaseModel, K extends keyof T>(
     this: ObjectType<T>,
     key: K,
-    values: T[K][]
+    values: QueryValue<T[K]>[]
   ): QueryBuilder<T> {
     const queryBuilder = new QueryBuilder(this)
 
@@ -435,16 +438,17 @@ export default class BaseModel {
    *
    * Example
    * ```
-   * const users = await User.whereNotIn('id', [1, 2, 3]).get();
+   * const users = await User.whereNotIn('id', ['1', '2', '3']).get();
    * ```
    *
    * @param key - A property of the model
-   * @param values - The values to exclude, type-checked against the model's property type
+   * @param values - The values to exclude, type-checked against the model's
+   *   property type. Array fields also accept their element type.
    */
   static whereNotIn<T extends BaseModel, K extends keyof T>(
     this: ObjectType<T>,
     key: K,
-    values: T[K][]
+    values: QueryValue<T[K]>[]
   ): QueryBuilder<T> {
     const queryBuilder = new QueryBuilder(this)
 

--- a/packages/esix/src/index.ts
+++ b/packages/esix/src/index.ts
@@ -3,6 +3,7 @@ import { ConnectionHandler, connectionHandler } from './connection-handler'
 import { getCollectionName } from './naming'
 import QueryBuilder, { type Query } from './query-builder'
 import {
+  type ComparisonOperator,
   type ObjectType,
   type Dictionary,
   type Document,
@@ -16,4 +17,11 @@ export {
   connectionHandler,
   getCollectionName
 }
-export type { Query, ObjectType, Dictionary, Document, Paginated }
+export type {
+  ComparisonOperator,
+  Query,
+  ObjectType,
+  Dictionary,
+  Document,
+  Paginated
+}

--- a/packages/esix/src/index.ts
+++ b/packages/esix/src/index.ts
@@ -4,10 +4,11 @@ import { getCollectionName } from './naming'
 import QueryBuilder, { type Query } from './query-builder'
 import {
   type ComparisonOperator,
-  type ObjectType,
   type Dictionary,
   type Document,
-  type Paginated
+  type ObjectType,
+  type Paginated,
+  type QueryValue
 } from './types'
 
 export {
@@ -19,9 +20,10 @@ export {
 }
 export type {
   ComparisonOperator,
-  Query,
-  ObjectType,
   Dictionary,
   Document,
-  Paginated
+  ObjectType,
+  Paginated,
+  Query,
+  QueryValue
 }

--- a/packages/esix/src/injection.spec.ts
+++ b/packages/esix/src/injection.spec.ts
@@ -34,7 +34,7 @@ describe('Injections', () => {
     })
 
     const user = await User.where('username', username)
-      .where('password', password)
+      .where('password', password as any)
       .first()
 
     expect(user).toBeNull()
@@ -48,7 +48,7 @@ describe('Injections', () => {
 
     const users = await User.where('username', {
       nested: { $gt: '' }
-    }).get()
+    } as any).get()
 
     expect(users).toEqual([])
   })

--- a/packages/esix/src/query-builder.ts
+++ b/packages/esix/src/query-builder.ts
@@ -413,14 +413,15 @@ export default class QueryBuilder<T extends BaseModel> {
    * @param query - A query object to filter by
    * @param key - Property name to filter by (must be a valid model field)
    * @param operatorOrValue - Comparison operator or value when using 2-param syntax
-   * @param value - The value to filter by when using 3-param syntax with operator
+   * @param value - The value to filter by, type-checked against the model's
+   *   property type. Array fields also accept their element type.
    */
   orWhere(query: Query): QueryBuilder<T>
-  orWhere<K extends keyof T>(key: K, value: T[K]): QueryBuilder<T>
+  orWhere<K extends keyof T>(key: K, value: QueryValue<T[K]>): QueryBuilder<T>
   orWhere<K extends keyof T>(
     key: K,
     operator: ComparisonOperator,
-    value: T[K]
+    value: QueryValue<T[K]>
   ): QueryBuilder<T>
   orWhere(
     queryOrKey: Query | string,

--- a/packages/esix/src/query-builder.ts
+++ b/packages/esix/src/query-builder.ts
@@ -609,14 +609,14 @@ export default class QueryBuilder<T extends BaseModel> {
    * @param query - A query object to filter by
    * @param key - Property name to filter by (must be a valid model field)
    * @param operatorOrValue - Comparison operator or value when using 2-param syntax
-   * @param value - The value to filter by when using 3-param syntax with operator
+   * @param value - The value to filter by, type-checked against the model's property type
    */
   where(query: Query): QueryBuilder<T>
-  where<K extends keyof T>(key: K, value: any): QueryBuilder<T>
+  where<K extends keyof T>(key: K, value: T[K]): QueryBuilder<T>
   where<K extends keyof T>(
     key: K,
     operator: ComparisonOperator,
-    value: any
+    value: T[K]
   ): QueryBuilder<T>
   where(
     queryOrKey: Query | string,
@@ -668,9 +668,9 @@ export default class QueryBuilder<T extends BaseModel> {
    * Returns all the models with `key` in the array of `values`.
    *
    * @param key - A property of the model
-   * @param values
+   * @param values - The values to match, type-checked against the model's property type
    */
-  whereIn<K extends keyof T>(key: K, values: any[]): QueryBuilder<T>
+  whereIn<K extends keyof T>(key: K, values: T[K][]): QueryBuilder<T>
   whereIn(key: string, values: any[]): QueryBuilder<T> {
     const keyStr = key === 'id' ? '_id' : key
 
@@ -687,9 +687,9 @@ export default class QueryBuilder<T extends BaseModel> {
    * Returns all the models with `key` not in the array of `values`.
    *
    * @param key - A property of the model
-   * @param values
+   * @param values - The values to exclude, type-checked against the model's property type
    */
-  whereNotIn<K extends keyof T>(key: K, values: any[]): QueryBuilder<T>
+  whereNotIn<K extends keyof T>(key: K, values: T[K][]): QueryBuilder<T>
   whereNotIn(key: string, values: any[]): QueryBuilder<T> {
     const keyStr = key === 'id' ? '_id' : key
 

--- a/packages/esix/src/query-builder.ts
+++ b/packages/esix/src/query-builder.ts
@@ -10,7 +10,8 @@ import type {
   Dictionary,
   Document,
   ObjectType,
-  Paginated
+  Paginated,
+  QueryValue
 } from './types'
 
 /**
@@ -609,14 +610,15 @@ export default class QueryBuilder<T extends BaseModel> {
    * @param query - A query object to filter by
    * @param key - Property name to filter by (must be a valid model field)
    * @param operatorOrValue - Comparison operator or value when using 2-param syntax
-   * @param value - The value to filter by, type-checked against the model's property type
+   * @param value - The value to filter by, type-checked against the model's
+   *   property type. Array fields also accept their element type.
    */
   where(query: Query): QueryBuilder<T>
-  where<K extends keyof T>(key: K, value: T[K]): QueryBuilder<T>
+  where<K extends keyof T>(key: K, value: QueryValue<T[K]>): QueryBuilder<T>
   where<K extends keyof T>(
     key: K,
     operator: ComparisonOperator,
-    value: T[K]
+    value: QueryValue<T[K]>
   ): QueryBuilder<T>
   where(
     queryOrKey: Query | string,
@@ -668,9 +670,13 @@ export default class QueryBuilder<T extends BaseModel> {
    * Returns all the models with `key` in the array of `values`.
    *
    * @param key - A property of the model
-   * @param values - The values to match, type-checked against the model's property type
+   * @param values - The values to match, type-checked against the model's
+   *   property type. Array fields also accept their element type.
    */
-  whereIn<K extends keyof T>(key: K, values: T[K][]): QueryBuilder<T>
+  whereIn<K extends keyof T>(
+    key: K,
+    values: QueryValue<T[K]>[]
+  ): QueryBuilder<T>
   whereIn(key: string, values: any[]): QueryBuilder<T> {
     const keyStr = key === 'id' ? '_id' : key
 
@@ -687,9 +693,13 @@ export default class QueryBuilder<T extends BaseModel> {
    * Returns all the models with `key` not in the array of `values`.
    *
    * @param key - A property of the model
-   * @param values - The values to exclude, type-checked against the model's property type
+   * @param values - The values to exclude, type-checked against the model's
+   *   property type. Array fields also accept their element type.
    */
-  whereNotIn<K extends keyof T>(key: K, values: T[K][]): QueryBuilder<T>
+  whereNotIn<K extends keyof T>(
+    key: K,
+    values: QueryValue<T[K]>[]
+  ): QueryBuilder<T>
   whereNotIn(key: string, values: any[]): QueryBuilder<T> {
     const keyStr = key === 'id' ? '_id' : key
 

--- a/packages/esix/src/type-safety.spec.ts
+++ b/packages/esix/src/type-safety.spec.ts
@@ -6,6 +6,7 @@
  * produce type errors - if they don't, the test file won't compile.
  *
  * Related to: https://github.com/Artmann/esix/issues/60
+ * Related to: https://github.com/Artmann/esix/issues/68
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import BaseModel from './base-model'
@@ -53,6 +54,13 @@ class User extends BaseModel {
  */
 class Article extends BaseModel {
   public publishedAt: Date | null = null
+}
+
+/**
+ * Test model with an array-typed field
+ */
+class Post extends BaseModel {
+  public tags: string[] = []
 }
 
 describe('Type Safety for Model Fields', () => {
@@ -251,6 +259,16 @@ describe('Type Safety for Query Values', () => {
 
       expect(true).toBe(true)
     })
+
+    it('accepts the element type for array fields', () => {
+      Post.where('tags', 'news')
+      Post.where('tags', ['news'])
+
+      // @ts-expect-error - 'tags' is a string array field, not a number field
+      Post.where('tags', 5)
+
+      expect(true).toBe(true)
+    })
   })
 
   describe('whereIn method', () => {
@@ -259,6 +277,15 @@ describe('Type Safety for Query Values', () => {
 
       // @ts-expect-error - 'price' is a number field, not a string field
       MenuItem.whereIn('price', ['1'])
+
+      expect(true).toBe(true)
+    })
+
+    it('accepts the element type for array fields', () => {
+      Post.whereIn('tags', ['a', 'b'])
+
+      // @ts-expect-error - 'tags' is a string array field, not a number field
+      Post.whereIn('tags', [5])
 
       expect(true).toBe(true)
     })

--- a/packages/esix/src/type-safety.spec.ts
+++ b/packages/esix/src/type-safety.spec.ts
@@ -48,6 +48,13 @@ class User extends BaseModel {
   public isActive = true
 }
 
+/**
+ * Test model with a union-typed field
+ */
+class Article extends BaseModel {
+  public publishedAt: Date | null = null
+}
+
 describe('Type Safety for Model Fields', () => {
   beforeEach(() => {
     Object.assign(process.env, {
@@ -185,6 +192,84 @@ describe('Type Safety for Model Fields', () => {
 
       // @ts-expect-error - 'sortOrder' is not a valid field
       MenuItem.orderBy('sortOrder', 'desc')
+
+      expect(true).toBe(true)
+    })
+  })
+})
+
+describe('Type Safety for Query Values', () => {
+  beforeEach(() => {
+    Object.assign(process.env, {
+      DB_ADAPTER: 'mock',
+      DB_DATABASE: 'test'
+    })
+  })
+
+  describe('where method', () => {
+    it('accepts values matching the field type', () => {
+      MenuItem.where('price', 9.99)
+      MenuItem.where('price', '>', 10)
+
+      expect(true).toBe(true)
+    })
+
+    it('rejects values that do not match the field type', () => {
+      // @ts-expect-error - 'price' is a number field, not a string field
+      MenuItem.where('price', 'ten')
+
+      // @ts-expect-error - 'available' is a boolean field, not a string field
+      MenuItem.where('available', 'yes')
+
+      // @ts-expect-error - 'price' is a number field, not a string field
+      MenuItem.where('price', '>', '10')
+
+      expect(true).toBe(true)
+    })
+
+    it('type-checks values in chained where calls', () => {
+      MenuItem.where('available', true).where('price', '>', 5)
+
+      // @ts-expect-error - 'price' is a number field, not a string field
+      MenuItem.where('available', true).where('price', 'ten')
+
+      expect(true).toBe(true)
+    })
+
+    it('accepts every member of a union-typed field', () => {
+      Article.where('publishedAt', null)
+      Article.where('publishedAt', '>', new Date())
+
+      // @ts-expect-error - 'publishedAt' is a Date | null field, not a number field
+      Article.where('publishedAt', 123)
+
+      expect(true).toBe(true)
+    })
+
+    it('still accepts raw query objects', () => {
+      MenuItem.limit(1).where({ price: { $gt: 5 } })
+
+      expect(true).toBe(true)
+    })
+  })
+
+  describe('whereIn method', () => {
+    it('accepts values matching the field type', () => {
+      MenuItem.whereIn('price', [5, 10])
+
+      // @ts-expect-error - 'price' is a number field, not a string field
+      MenuItem.whereIn('price', ['1'])
+
+      expect(true).toBe(true)
+    })
+  })
+
+  describe('whereNotIn method', () => {
+    it('accepts values matching the field type', () => {
+      MenuItem.whereNotIn('name', ['x'])
+
+      // @ts-expect-error - 'name' is a string field, not a number field
+      MenuItem.whereNotIn('name', [1])
 
       expect(true).toBe(true)
     })

--- a/packages/esix/src/type-safety.spec.ts
+++ b/packages/esix/src/type-safety.spec.ts
@@ -244,6 +244,15 @@ describe('Type Safety for Query Values', () => {
       expect(true).toBe(true)
     })
 
+    it('type-checks values in orWhere calls', () => {
+      MenuItem.where('price', 5).orWhere('price', '>', 10)
+
+      // @ts-expect-error - 'price' is a number field, not a string field
+      MenuItem.where('price', 5).orWhere('price', 'ten')
+
+      expect(true).toBe(true)
+    })
+
     it('accepts every member of a union-typed field', () => {
       Article.where('publishedAt', null)
       Article.where('publishedAt', '>', new Date())

--- a/packages/esix/src/types.ts
+++ b/packages/esix/src/types.ts
@@ -23,6 +23,13 @@ export type Document = { [index: string]: any }
 export type ComparisonOperator = '=' | '!=' | '<>' | '>' | '>=' | '<' | '<='
 
 /**
+ * The values accepted when querying a field of type `V`. Scalar fields
+ * accept `V` itself. Array fields also accept their element type, since
+ * MongoDB matches documents where the array contains the given value.
+ */
+export type QueryValue<V> = V | (V extends readonly (infer E)[] ? E : never)
+
+/**
  * Result of QueryBuilder.paginate() / BaseModel.paginate(). Bundles the
  * page of models with the metadata needed to render pagination UIs.
  */

--- a/packages/website/docs/retrieving-models.md
+++ b/packages/website/docs/retrieving-models.md
@@ -182,7 +182,11 @@ const popularPosts = await BlogPost
 
 Note: The two-parameter syntax `where('status', 'published')` is still supported for equality comparisons and remains the recommended approach for simple equality checks.
 
-The values you pass to `where`, `whereIn`, and `whereNotIn` are type-checked against the model's property types, so passing a string to a numeric field like `where('age', '>', '18')` is caught at compile time.
+The values you pass to `where`, `whereIn`, and `whereNotIn` are type-checked
+against the model's property types, so passing a string to a numeric field
+like `where('age', '>', '18')` is caught at compile time. For array fields,
+the element type is also accepted, so `where('tags', 'news')` compiles when
+`tags` is a `string[]`.
 
 ## Null Checks
 
@@ -256,7 +260,7 @@ You can use `whereIn` to retrieve models where a column's value is within a
 given array:
 
 ```ts
-const users = await User.whereIn('id', [1, 2, 3]).get()
+const users = await User.whereIn('id', ['1', '2', '3']).get()
 ```
 
 | id  | name    | age | status     |
@@ -269,7 +273,7 @@ Conversely, you can use `whereNotIn` to retrieve models where a column's value
 is not within a given array:
 
 ```ts
-const users = await User.whereNotIn('id', [1, 2, 3]).get()
+const users = await User.whereNotIn('id', ['1', '2', '3']).get()
 ```
 
 | id  | name      | age | status   |

--- a/packages/website/docs/retrieving-models.md
+++ b/packages/website/docs/retrieving-models.md
@@ -182,11 +182,11 @@ const popularPosts = await BlogPost
 
 Note: The two-parameter syntax `where('status', 'published')` is still supported for equality comparisons and remains the recommended approach for simple equality checks.
 
-The values you pass to `where`, `whereIn`, and `whereNotIn` are type-checked
-against the model's property types, so passing a string to a numeric field
-like `where('age', '>', '18')` is caught at compile time. For array fields,
-the element type is also accepted, so `where('tags', 'news')` compiles when
-`tags` is a `string[]`.
+The values you pass to `where`, `orWhere`, `whereIn`, and `whereNotIn` are
+type-checked against the model's property types, so passing a string to a
+numeric field like `where('age', '>', '18')` is caught at compile time. For
+array fields, the element type is also accepted, so `where('tags', 'news')`
+compiles when `tags` is a `string[]`.
 
 ## Null Checks
 

--- a/packages/website/docs/retrieving-models.md
+++ b/packages/website/docs/retrieving-models.md
@@ -182,6 +182,8 @@ const popularPosts = await BlogPost
 
 Note: The two-parameter syntax `where('status', 'published')` is still supported for equality comparisons and remains the recommended approach for simple equality checks.
 
+The values you pass to `where`, `whereIn`, and `whereNotIn` are type-checked against the model's property types, so passing a string to a numeric field like `where('age', '>', '18')` is caught at compile time.
+
 ## Null Checks
 
 Use `whereNull` to retrieve models where a field is `null`. Following


### PR DESCRIPTION
Tightens the value types on the public query methods so field-value mistakes are caught at compile time, the same way `findBy` already works (#68):

- `where(key, value)` and `where(key, operator, value)` now take `QueryValue<T[K]>`.
- `whereIn(key, values)` and `whereNotIn(key, values)` now take `QueryValue<T[K]>[]`.
- Applied to both `QueryBuilder` and the `BaseModel` statics. Keys were already typed as `keyof T`.
- `orderBy` needed no change — it was already fully typed (`keyof T` keys, `'asc' | 'desc'`).

## Array fields

Plain `T[K]` would reject legitimate MongoDB patterns on array fields (`where('tags', 'news')` array-contains equality, `whereIn('tags', ['a', 'b'])` element matching). The new exported helper type accommodates them:

```ts
type QueryValue<V> = V | (V extends readonly (infer E)[] ? E : never)
```

Scalar fields accept the property type; array fields also accept their element type.

## Breaking change (intentional)

Loosely-typed callers — e.g. raw operator objects passed as where-values — no longer compile. That looseness was misleading anyway: `sanitize()` strips `$`-prefixed keys from values at runtime, so those calls never worked. Escape hatch for advanced filters: the raw `where(query: Query)` object overload on `QueryBuilder`.

## New exports

`ComparisonOperator` and `QueryValue` are now exported from the package root (both appear in public signatures).

## CI

Adds `.github/workflows/typecheck.yml` (mirrors lint.yml) so the compile-time `@ts-expect-error` tests in `type-safety.spec.ts` are enforced in CI — previously nothing in CI ran `yarn typecheck`.

## Merge order

Rebased onto main with #71 (`whereNull`/`whereNotNull`/`orWhere`) already merged; `orWhere`'s 2- and 3-param values are typed `QueryValue<T[K]>` here for consistency with the tightened `where`. Merge #72 and #73 in either order; #74 should merge last.

## Tests

- New "Type Safety for Query Values" block in `type-safety.spec.ts`: valid and `@ts-expect-error` cases for all four methods, a `Date | null` union model, array-field cases, and the raw-object escape hatch.
- `injection.spec.ts` payloads cast with `as any` (they intentionally simulate unvalidated runtime input); runtime assertions unchanged.
- Full suite: 175/175 passing; lint, typecheck, and build clean.

Closes #68
