### PR TITLE
feat: add wasRecentlyCreated flag and make firstOrCreate atomic

### DIFF
--- a/packages/esix/src/base-model.spec.ts
+++ b/packages/esix/src/base-model.spec.ts
@@ -20,6 +20,7 @@ const collection = {
   deleteMany: vi.fn(),
   find: vi.fn(),
   findOne: vi.fn(),
+  findOneAndUpdate: vi.fn(),
   insertOne: vi.fn(),
   updateOne: vi.fn(),
   count: vi.fn(),
@@ -197,6 +198,8 @@ describe('BaseModel', () => {
         title: 'Wuthering Heights',
         updatedAt: null
       })
+
+      expect(book.wasRecentlyCreated).toBe(true)
     })
 
     it('creates a new Model with the given id.', async () => {
@@ -251,6 +254,8 @@ describe('BaseModel', () => {
         title: 'Wuthering Heights',
         updatedAt: null
       })
+
+      expect(book.wasRecentlyCreated).toBe(true)
     })
 
     it('includes the default values for the model.', async () => {
@@ -1058,15 +1063,26 @@ describe('BaseModel', () => {
 
   describe('firstOrCreate', () => {
     it('returns existing model if found', async () => {
-      collection.findOne.mockResolvedValue({
-        _id: '5f0aeaeacff57e3ec676b340',
-        authorId: 'author-1',
-        createdAt: 1594552340652,
-        isAvailable: true,
-        isbn: '9780486284736',
-        pages: 279,
-        title: 'Pride and Prejudice',
-        updatedAt: null
+      vi.useFakeTimers()
+      vi.setSystemTime(new Date('2023-01-01T10:00:00Z'))
+
+      vi.mocked(ObjectId.prototype.toHexString).mockReturnValueOnce(
+        '5f0aefba348289a81889a955'
+      )
+
+      collection.findOneAndUpdate.mockResolvedValue({
+        lastErrorObject: { updatedExisting: true },
+        ok: 1,
+        value: {
+          _id: '5f0aeaeacff57e3ec676b340',
+          authorId: 'author-1',
+          createdAt: 1594552340652,
+          isAvailable: true,
+          isbn: '9780486284736',
+          pages: 279,
+          title: 'Pride and Prejudice',
+          updatedAt: null
+        }
       })
 
       const book = await Book.firstOrCreate(
@@ -1079,9 +1095,26 @@ describe('BaseModel', () => {
         }
       )
 
-      expect(collection.findOne).toHaveBeenCalledWith({
-        isbn: '9780486284736'
-      })
+      expect(collection.findOneAndUpdate).toHaveBeenCalledWith(
+        { isbn: '9780486284736' },
+        {
+          $setOnInsert: {
+            _id: '5f0aefba348289a81889a955',
+            authorId: 'author-2',
+            createdAt: new Date('2023-01-01T10:00:00Z').getTime(),
+            isAvailable: true,
+            isbn: '9780486284736',
+            pages: 279,
+            title: 'Pride and Prejudice',
+            updatedAt: null
+          }
+        },
+        {
+          includeResultMetadata: true,
+          returnDocument: 'after',
+          upsert: true
+        }
+      )
 
       expect(book).toEqual({
         authorId: 'author-1',
@@ -1093,6 +1126,8 @@ describe('BaseModel', () => {
         title: 'Pride and Prejudice',
         updatedAt: null
       })
+
+      expect(book.wasRecentlyCreated).toBe(false)
     })
 
     it('creates new model if not found', async () => {
@@ -1103,19 +1138,22 @@ describe('BaseModel', () => {
         '5f0aefba348289a81889a955'
       )
 
-      collection.findOne.mockResolvedValueOnce(null)
-      collection.insertOne.mockResolvedValue({
-        insertedId: '5f0aefba348289a81889a955'
-      })
-      collection.findOne.mockResolvedValueOnce({
-        _id: '5f0aefba348289a81889a955',
-        authorId: 'author-2',
-        createdAt: new Date('2023-01-01T10:00:00Z').getTime(),
-        isAvailable: true,
-        isbn: '9780140449266',
-        pages: 688,
-        title: 'Crime and Punishment',
-        updatedAt: null
+      collection.findOneAndUpdate.mockResolvedValue({
+        lastErrorObject: {
+          updatedExisting: false,
+          upserted: '5f0aefba348289a81889a955'
+        },
+        ok: 1,
+        value: {
+          _id: '5f0aefba348289a81889a955',
+          authorId: 'author-2',
+          createdAt: new Date('2023-01-01T10:00:00Z').getTime(),
+          isAvailable: true,
+          isbn: '9780140449266',
+          pages: 688,
+          title: 'Crime and Punishment',
+          updatedAt: null
+        }
       })
 
       const book = await Book.firstOrCreate(
@@ -1128,20 +1166,26 @@ describe('BaseModel', () => {
         }
       )
 
-      expect(collection.findOne).toHaveBeenCalledWith({
-        isbn: '9780140449266'
-      })
-
-      expect(collection.insertOne).toHaveBeenCalledWith({
-        _id: '5f0aefba348289a81889a955',
-        authorId: 'author-2',
-        createdAt: new Date('2023-01-01T10:00:00Z').getTime(),
-        isAvailable: true,
-        isbn: '9780140449266',
-        pages: 688,
-        title: 'Crime and Punishment',
-        updatedAt: null
-      })
+      expect(collection.findOneAndUpdate).toHaveBeenCalledWith(
+        { isbn: '9780140449266' },
+        {
+          $setOnInsert: {
+            _id: '5f0aefba348289a81889a955',
+            authorId: 'author-2',
+            createdAt: new Date('2023-01-01T10:00:00Z').getTime(),
+            isAvailable: true,
+            isbn: '9780140449266',
+            pages: 688,
+            title: 'Crime and Punishment',
+            updatedAt: null
+          }
+        },
+        {
+          includeResultMetadata: true,
+          returnDocument: 'after',
+          upsert: true
+        }
+      )
 
       expect(book).toEqual({
         authorId: 'author-2',
@@ -1153,6 +1197,8 @@ describe('BaseModel', () => {
         title: 'Crime and Punishment',
         updatedAt: null
       })
+
+      expect(book.wasRecentlyCreated).toBe(true)
     })
 
     it('creates new model using filter as attributes when attributes not provided', async () => {
@@ -1163,19 +1209,22 @@ describe('BaseModel', () => {
         '5f0aefba348289a81889a956'
       )
 
-      collection.findOne.mockResolvedValueOnce(null)
-      collection.insertOne.mockResolvedValue({
-        insertedId: '5f0aefba348289a81889a956'
-      })
-      collection.findOne.mockResolvedValueOnce({
-        _id: '5f0aefba348289a81889a956',
-        authorId: 'author-3',
-        createdAt: new Date('2023-01-01T10:00:00Z').getTime(),
-        isAvailable: true,
-        isbn: '9780486282114',
-        pages: 320,
-        title: 'The Great Gatsby',
-        updatedAt: null
+      collection.findOneAndUpdate.mockResolvedValue({
+        lastErrorObject: {
+          updatedExisting: false,
+          upserted: '5f0aefba348289a81889a956'
+        },
+        ok: 1,
+        value: {
+          _id: '5f0aefba348289a81889a956',
+          authorId: 'author-3',
+          createdAt: new Date('2023-01-01T10:00:00Z').getTime(),
+          isAvailable: true,
+          isbn: '9780486282114',
+          pages: 320,
+          title: 'The Great Gatsby',
+          updatedAt: null
+        }
       })
 
       const book = await Book.firstOrCreate({
@@ -1185,23 +1234,31 @@ describe('BaseModel', () => {
         authorId: 'author-3'
       })
 
-      expect(collection.findOne).toHaveBeenCalledWith({
-        title: 'The Great Gatsby',
-        isbn: '9780486282114',
-        pages: 320,
-        authorId: 'author-3'
-      })
-
-      expect(collection.insertOne).toHaveBeenCalledWith({
-        _id: '5f0aefba348289a81889a956',
-        authorId: 'author-3',
-        createdAt: new Date('2023-01-01T10:00:00Z').getTime(),
-        isAvailable: true,
-        isbn: '9780486282114',
-        pages: 320,
-        title: 'The Great Gatsby',
-        updatedAt: null
-      })
+      expect(collection.findOneAndUpdate).toHaveBeenCalledWith(
+        {
+          title: 'The Great Gatsby',
+          isbn: '9780486282114',
+          pages: 320,
+          authorId: 'author-3'
+        },
+        {
+          $setOnInsert: {
+            _id: '5f0aefba348289a81889a956',
+            authorId: 'author-3',
+            createdAt: new Date('2023-01-01T10:00:00Z').getTime(),
+            isAvailable: true,
+            isbn: '9780486282114',
+            pages: 320,
+            title: 'The Great Gatsby',
+            updatedAt: null
+          }
+        },
+        {
+          includeResultMetadata: true,
+          returnDocument: 'after',
+          upsert: true
+        }
+      )
 
       expect(book).toEqual({
         authorId: 'author-3',
@@ -1213,6 +1270,8 @@ describe('BaseModel', () => {
         title: 'The Great Gatsby',
         updatedAt: null
       })
+
+      expect(book.wasRecentlyCreated).toBe(true)
     })
   })
 

--- a/packages/esix/src/base-model.spec.ts
+++ b/packages/esix/src/base-model.spec.ts
@@ -1273,6 +1273,68 @@ describe('BaseModel', () => {
 
       expect(book.wasRecentlyCreated).toBe(true)
     })
+
+    it('falls back to findOne when a concurrent upsert wins the duplicate key race', async () => {
+      collection.findOneAndUpdate.mockRejectedValue(
+        Object.assign(new Error('E11000 duplicate key'), { code: 11000 })
+      )
+      collection.findOne.mockResolvedValue({
+        _id: '5f0aeaeacff57e3ec676b340',
+        authorId: 'author-1',
+        createdAt: 1594552340652,
+        isAvailable: true,
+        isbn: '9780486284736',
+        pages: 279,
+        title: 'Pride and Prejudice',
+        updatedAt: null
+      })
+
+      const book = await Book.firstOrCreate({ isbn: '9780486284736' })
+
+      expect(collection.findOne).toHaveBeenCalledWith({
+        isbn: '9780486284736'
+      })
+
+      expect(book).toEqual({
+        authorId: 'author-1',
+        createdAt: 1594552340652,
+        id: '5f0aeaeacff57e3ec676b340',
+        isAvailable: true,
+        isbn: '9780486284736',
+        pages: 279,
+        title: 'Pride and Prejudice',
+        updatedAt: null
+      })
+
+      expect(book.wasRecentlyCreated).toBe(false)
+    })
+
+    it('rethrows the duplicate key error when the fallback findOne finds nothing', async () => {
+      collection.findOneAndUpdate.mockRejectedValue(
+        Object.assign(new Error('E11000 duplicate key'), { code: 11000 })
+      )
+      collection.findOne.mockResolvedValue(null)
+
+      await expect(
+        Book.firstOrCreate({ isbn: '9780486284736' })
+      ).rejects.toThrow('E11000 duplicate key')
+
+      expect(collection.findOne).toHaveBeenCalledWith({
+        isbn: '9780486284736'
+      })
+    })
+
+    it('rethrows non duplicate key errors without falling back to findOne', async () => {
+      collection.findOneAndUpdate.mockRejectedValue(
+        new Error('connection lost')
+      )
+
+      await expect(
+        Book.firstOrCreate({ isbn: '9780486284736' })
+      ).rejects.toThrow('connection lost')
+
+      expect(collection.findOne).not.toHaveBeenCalled()
+    })
   })
 
   describe('Static Aggregation Functions', () => {

--- a/packages/esix/src/base-model.ts
+++ b/packages/esix/src/base-model.ts
@@ -20,7 +20,9 @@ export default class BaseModel {
    * path of `firstOrCreate()`. Models retrieved from the database always have
    * this set to `false`.
    *
-   * This is runtime metadata and is never persisted to the database.
+   * This is runtime metadata and is never persisted to the database. Models
+   * must not redeclare this field: doing so throws a `TypeError` at
+   * construction because the property is defined as non-configurable.
    */
   declare wasRecentlyCreated: boolean
 

--- a/packages/esix/src/base-model.ts
+++ b/packages/esix/src/base-model.ts
@@ -15,6 +15,24 @@ export default class BaseModel {
   public updatedAt: number | null = null
 
   /**
+   * True when this instance was inserted into the database by the current
+   * process, either through `create()`, an inserting `save()`, or the create
+   * path of `firstOrCreate()`. Models retrieved from the database always have
+   * this set to `false`.
+   *
+   * This is runtime metadata and is never persisted to the database.
+   */
+  declare wasRecentlyCreated: boolean
+
+  constructor() {
+    Object.defineProperty(this, 'wasRecentlyCreated', {
+      enumerable: false,
+      value: false,
+      writable: true
+    })
+  }
+
+  /**
    * Direct access to Mongo's aggregation functions.
    *
    * Example
@@ -94,18 +112,8 @@ export default class BaseModel {
   ): Promise<T> {
     const queryBuilder = new QueryBuilder(this)
 
-    const instance = new this()
-    const defaultValues = Object.getOwnPropertyNames(instance).reduce(
-      (acc: Record<string, any>, key) => {
-        acc[key] = instance[key as keyof T]
-
-        return acc
-      },
-      {}
-    )
-
     const attributesWithDefaults = {
-      ...defaultValues,
+      ...getDefaultValues(this),
       ...attributes
     }
 
@@ -120,6 +128,8 @@ export default class BaseModel {
           `The document was inserted but could not be retrieved afterwards.`
       )
     }
+
+    model.wasRecentlyCreated = true
 
     return model
   }
@@ -166,6 +176,12 @@ export default class BaseModel {
    * Find a model matching the filter, or create a new one with the given attributes.
    * If attributes are not provided, the filter will be used as the attributes.
    *
+   * The lookup and the insert happen in a single atomic `findOneAndUpdate`
+   * operation. The returned model's `wasRecentlyCreated` property tells you
+   * whether the model was created (`true`) or an existing one was found
+   * (`false`). Note that guarding against duplicate inserts from concurrent
+   * callers requires a unique index on the filter fields.
+   *
    * Example
    * ```
    * // Retrieve flight by name or create it if it doesn't exist...
@@ -178,10 +194,15 @@ export default class BaseModel {
    *   { name: 'London to Paris' },
    *   { delayed: 1, arrival_time: '11:30' }
    * );
+   *
+   * if (flight.wasRecentlyCreated) {
+   *   console.log('Created a new flight.');
+   * }
    * ```
    *
    * @param filter - Object to search for existing model
    * @param attributes - Attributes to use when creating new model (optional, defaults to filter)
+   * @returns The found or created model, with `wasRecentlyCreated` set accordingly
    */
   static async firstOrCreate<T extends BaseModel>(
     this: ObjectType<T>,
@@ -190,13 +211,13 @@ export default class BaseModel {
   ): Promise<T> {
     const queryBuilder = new QueryBuilder(this)
 
-    const existingModel = await queryBuilder.findOne(filter)
+    const { model } = await queryBuilder.firstOrCreate(filter, {
+      ...getDefaultValues(this),
+      ...filter,
+      ...attributes
+    })
 
-    if (existingModel) {
-      return existingModel
-    }
-
-    return (this as any).create({ ...filter, ...attributes })
+    return model
   }
 
   /**
@@ -547,6 +568,7 @@ export default class BaseModel {
       this.updatedAt = Date.now()
     } else {
       this.createdAt = Date.now()
+      this.wasRecentlyCreated = true
     }
 
     const attributes = { ...this }
@@ -557,4 +579,16 @@ export default class BaseModel {
       this.id = id
     }
   }
+}
+
+function getDefaultValues<T extends BaseModel>(
+  ctor: ObjectType<T>
+): Record<string, any> {
+  const instance = new ctor()
+
+  return Object.keys(instance).reduce((acc: Record<string, any>, key) => {
+    acc[key] = instance[key as keyof T]
+
+    return acc
+  }, {})
 }

--- a/packages/esix/src/integration-test.spec.ts
+++ b/packages/esix/src/integration-test.spec.ts
@@ -1002,6 +1002,25 @@ describe('FirstOrCreate', () => {
     const numberOfFlights = await Flight.count()
     expect(numberOfFlights).toBe(1)
   })
+
+  it('does not persist wasRecentlyCreated when it is included in the filter', async () => {
+    const flight = await Flight.firstOrCreate({
+      name: 'Evil Filter Airways',
+      wasRecentlyCreated: true
+    })
+
+    expect(flight.wasRecentlyCreated).toBe(true)
+    expect(flight.name).toBe('Evil Filter Airways')
+
+    // MongoDB copies filter equality fields into upsert-inserted documents,
+    // so assert on the raw stored document to catch any leak.
+    const connection = await connectionHandler.getConnection()
+    const collection = await connection.collection('flights')
+    const document = await collection.findOne({ name: 'Evil Filter Airways' })
+
+    expect(document).not.toBeNull()
+    expect(document).not.toHaveProperty('wasRecentlyCreated')
+  })
 })
 
 describe('wasRecentlyCreated', () => {
@@ -1025,21 +1044,32 @@ describe('wasRecentlyCreated', () => {
   it('is never persisted to the database', async () => {
     const flight = await Flight.create({ name: 'Dublin to Vienna' })
 
-    const reloadedFlight = await Flight.find(flight.id)
-
-    expect(JSON.stringify(reloadedFlight)).not.toContain('wasRecentlyCreated')
-
     const savedFlight = new Flight()
 
     savedFlight.name = 'Vienna to Dublin'
 
     await savedFlight.save()
 
-    const reloadedSavedFlight = await Flight.find(savedFlight.id)
+    // Assert on the raw stored documents rather than reloaded models, as
+    // model hydration would absorb a leaked field into the non-enumerable
+    // property and hide it from serialization.
+    const connection = await connectionHandler.getConnection()
+    const collection = await connection.collection('flights')
 
-    expect(JSON.stringify(reloadedSavedFlight)).not.toContain(
-      'wasRecentlyCreated'
-    )
+    const createdDocument = await collection.findOne({ _id: flight.id as any })
+    const savedDocument = await collection.findOne({
+      _id: savedFlight.id as any
+    })
+
+    expect(createdDocument).not.toBeNull()
+    expect(createdDocument).not.toHaveProperty('wasRecentlyCreated')
+
+    expect(savedDocument).not.toBeNull()
+    expect(savedDocument).not.toHaveProperty('wasRecentlyCreated')
+
+    const reloadedFlight = await Flight.find(flight.id)
+
+    expect(JSON.stringify(reloadedFlight)).not.toContain('wasRecentlyCreated')
   })
 
   it('is true after saving a new instance and stays false for existing models', async () => {

--- a/packages/esix/src/integration-test.spec.ts
+++ b/packages/esix/src/integration-test.spec.ts
@@ -954,6 +954,115 @@ describe('FirstOrCreate', () => {
     const allFlights = await Flight.where('name', 'New York to London').get()
     expect(allFlights).toHaveLength(1)
   })
+
+  it('sets wasRecentlyCreated to false and leaves existing attributes untouched when found', async () => {
+    const existingFlight = await Flight.create({
+      name: 'Oslo to Berlin',
+      delayed: 0,
+      arrival_time: '09:15'
+    })
+
+    const flight = await Flight.firstOrCreate(
+      { name: 'Oslo to Berlin' },
+      { delayed: 1, arrival_time: '12:45' }
+    )
+
+    expect(flight.wasRecentlyCreated).toBe(false)
+    expect(flight.id).toBe(existingFlight.id)
+
+    // The attributes argument should not be applied to the existing document
+    expect(flight.delayed).toBe(0)
+    expect(flight.arrival_time).toBe('09:15')
+  })
+
+  it('sets wasRecentlyCreated to true when a new flight is created', async () => {
+    const flight = await Flight.firstOrCreate(
+      { name: 'Stockholm to Madrid' },
+      { delayed: 2 }
+    )
+
+    expect(flight.wasRecentlyCreated).toBe(true)
+
+    // Filter, attributes, and class defaults should all be present
+    expect(flight.name).toBe('Stockholm to Madrid')
+    expect(flight.delayed).toBe(2)
+    expect(flight.arrival_time).toBe('')
+    expect(flight.createdAt).toBeGreaterThan(0)
+    expect(flight.updatedAt).toBe(null)
+  })
+
+  it('reports created then found for sequential calls with the same filter', async () => {
+    const firstCall = await Flight.firstOrCreate({ name: 'Lisbon to Rome' })
+    const secondCall = await Flight.firstOrCreate({ name: 'Lisbon to Rome' })
+
+    expect(firstCall.wasRecentlyCreated).toBe(true)
+    expect(secondCall.wasRecentlyCreated).toBe(false)
+    expect(secondCall.id).toBe(firstCall.id)
+
+    const numberOfFlights = await Flight.count()
+    expect(numberOfFlights).toBe(1)
+  })
+})
+
+describe('wasRecentlyCreated', () => {
+  beforeEach(() => {
+    Object.assign(process.env, {
+      DB_ADAPTER: 'mock',
+      DB_DATABASE: `test-${createUuid()}`
+    })
+  })
+
+  it('is true for created models and false when they are retrieved again', async () => {
+    const flight = await Flight.create({ name: 'Tokyo to Seoul' })
+
+    expect(flight.wasRecentlyCreated).toBe(true)
+
+    const foundFlight = await Flight.find(flight.id)
+
+    expect(foundFlight?.wasRecentlyCreated).toBe(false)
+  })
+
+  it('is never persisted to the database', async () => {
+    const flight = await Flight.create({ name: 'Dublin to Vienna' })
+
+    const reloadedFlight = await Flight.find(flight.id)
+
+    expect(JSON.stringify(reloadedFlight)).not.toContain('wasRecentlyCreated')
+
+    const savedFlight = new Flight()
+
+    savedFlight.name = 'Vienna to Dublin'
+
+    await savedFlight.save()
+
+    const reloadedSavedFlight = await Flight.find(savedFlight.id)
+
+    expect(JSON.stringify(reloadedSavedFlight)).not.toContain(
+      'wasRecentlyCreated'
+    )
+  })
+
+  it('is true after saving a new instance and stays false for existing models', async () => {
+    const flight = new Flight()
+
+    flight.name = 'Helsinki to Warsaw'
+
+    await flight.save()
+
+    expect(flight.wasRecentlyCreated).toBe(true)
+
+    const existingFlight = await Flight.find(flight.id)
+
+    if (!existingFlight) {
+      throw new Error('Expected to find the saved flight.')
+    }
+
+    existingFlight.delayed = 1
+
+    await existingFlight.save()
+
+    expect(existingFlight.wasRecentlyCreated).toBe(false)
+  })
 })
 
 describe('Documentation', () => {

--- a/packages/esix/src/query-builder.ts
+++ b/packages/esix/src/query-builder.ts
@@ -297,6 +297,12 @@ export default class QueryBuilder<T extends BaseModel> {
     const sanitizedFilter: Query = {}
 
     for (const [key, value] of Object.entries(sanitized)) {
+      // MongoDB copies filter equality fields into upsert-inserted
+      // documents, and wasRecentlyCreated must never be persisted.
+      if (key === 'wasRecentlyCreated') {
+        continue
+      }
+
       sanitizedFilter[key === 'id' ? '_id' : key] = value
     }
 

--- a/packages/esix/src/query-builder.ts
+++ b/packages/esix/src/query-builder.ts
@@ -29,6 +29,8 @@ function isString(x: any): x is string {
 function normalizeAttributes(originalAttributes: Dictionary): Dictionary {
   const attributes = { ...originalAttributes }
 
+  delete attributes.wasRecentlyCreated
+
   if (!attributes.id) {
     attributes.id = new ObjectId().toHexString()
   }
@@ -276,6 +278,76 @@ export default class QueryBuilder<T extends BaseModel> {
     }
 
     return models[0]
+  }
+
+  /**
+   * Atomically returns the first document matching the filter, or inserts a
+   * new document with the given attributes using a single upsert. The
+   * returned model has `wasRecentlyCreated` set to whether it was created.
+   *
+   * @param filter
+   * @param attributes
+   * @internal
+   */
+  async firstOrCreate(
+    filter: Query,
+    attributes: Record<string, any>
+  ): Promise<{ created: boolean; model: T }> {
+    const sanitized = sanitize(filter) as Query
+    const sanitizedFilter: Query = {}
+
+    for (const [key, value] of Object.entries(sanitized)) {
+      sanitizedFilter[key === 'id' ? '_id' : key] = value
+    }
+
+    const insertAttributes = normalizeAttributes(sanitize(attributes))
+
+    return this.useCollection(async (collection) => {
+      let created: boolean
+      let document: Document | null
+
+      try {
+        const result = await collection.findOneAndUpdate(
+          sanitizedFilter,
+          { $setOnInsert: insertAttributes },
+          {
+            includeResultMetadata: true,
+            returnDocument: 'after',
+            upsert: true
+          }
+        )
+
+        created = !result?.lastErrorObject?.updatedExisting
+        document = result?.value ?? null
+      } catch (error) {
+        // Two concurrent upserts on a unique index can race; one of them
+        // fails with a duplicate key error. Fall back to reading the
+        // document the other writer inserted.
+        if (!isDuplicateKeyError(error)) {
+          throw error
+        }
+
+        created = false
+        document = await collection.findOne(sanitizedFilter)
+
+        if (!document) {
+          throw error
+        }
+      }
+
+      if (!document) {
+        throw new Error(
+          `Failed to create ${this.ctor.name} (id: ${String(insertAttributes._id)}). ` +
+            `The document was upserted but could not be retrieved afterwards.`
+        )
+      }
+
+      const model = this.createInstance<T>(document)
+
+      model.wasRecentlyCreated = created
+
+      return { created, model }
+    })
   }
 
   /**
@@ -735,6 +807,14 @@ export default class QueryBuilder<T extends BaseModel> {
 
     return result
   }
+}
+
+function isDuplicateKeyError(error: unknown): boolean {
+  if (!error || typeof error !== 'object') {
+    return false
+  }
+
+  return 'code' in error && (error as { code?: unknown }).code === 11000
 }
 
 function isNumberArray(array: any[]): array is number[] {

--- a/packages/website/docs/inserting-and-updating-models.md
+++ b/packages/website/docs/inserting-and-updating-models.md
@@ -69,6 +69,42 @@ want to search for. The second argument contains the additional attributes to
 add to the model if it doesn't exist. If the second argument is not provided,
 the attributes from the first argument will be used when creating the model.
 
+The lookup and the insert happen in a single atomic `findOneAndUpdate`
+operation, and the returned model tells you what happened through its
+`wasRecentlyCreated` property. It's `true` when the model was just created and
+`false` when an existing model was found, which makes it easy to keep track of
+created and skipped records in a seed script.
+
+```ts
+const results = { created: 0, skipped: 0 }
+
+for (const { isbn13, title } of books) {
+  const book = await Book.firstOrCreate({ isbn13 }, { title })
+
+  if (book.wasRecentlyCreated) {
+    results.created += 1
+  } else {
+    results.skipped += 1
+  }
+}
+
+console.log(`Created ${results.created} books, skipped ${results.skipped}.`)
+```
+
+```text
+Created 12 books, skipped 38.
+```
+
+`wasRecentlyCreated` is runtime metadata and is never stored in the database.
+Models retrieved from the database always have it set to `false`. It's also set
+to `true` on models returned from `create` and on new instances after their
+first `save`.
+
+To be fully safe against duplicate inserts from concurrent callers, add a
+[unique index](https://www.mongodb.com/docs/manual/core/index-unique/) on the
+filter fields. When two concurrent calls race, the losing call detects the
+duplicate key error and returns the model the winning call inserted.
+
 ## Increment & Decrement
 
 When you only need to bump a numeric field, use `increment` and `decrement`


### PR DESCRIPTION
Models now expose a Laravel-style `wasRecentlyCreated` flag, and `firstOrCreate` performs its lookup-or-insert as a single atomic MongoDB operation (#69).

## The wasRecentlyCreated flag

- `true` when the instance was inserted by the current process: `create()`, an inserting `save()`, or the create path of `firstOrCreate()`. Models retrieved from the database always have it set to `false`.
- It is runtime metadata and is **never persisted**: the property is defined non-enumerable on the instance (so spreads, `JSON.stringify`, and `toEqual` ignore it), `normalizeAttributes` strips it as a safety net, and `firstOrCreate` excludes it from the upsert filter so MongoDB cannot copy it into upsert-inserted documents.
- Subclasses must not redeclare the field; because it is defined non-configurable, redeclaring it throws a `TypeError` at construction.

## Atomic firstOrCreate

- Replaces the racy findOne-then-create round trip with one `findOneAndUpdate` upsert using `$setOnInsert`; `lastErrorObject.updatedExisting` determines whether the model was found or created. The public signature is unchanged (`Promise<T>`).
- When two concurrent upserts race on a unique index, the loser catches the duplicate key error (code 11000) and falls back to reading the document the winner inserted, returning it with `wasRecentlyCreated === false`. Full race-safety against duplicate inserts requires a unique index on the filter fields.

## Behavior change

The new filter path remaps `id` to `_id`, so `firstOrCreate({ id: existingId })` now finds the existing document. The old findOne-based path never matched on `id` and attempted a duplicate insert instead.

## Docs

Extended the "First or Create" section of Inserting & Updating Models with the flag semantics, a seed-script created/skipped counter example with example output, and the unique-index note.

## Tests

Unit tests pin the exact `findOneAndUpdate` call shape and the duplicate-key fallback (success, miss-rethrow, non-11000 rethrow); integration tests cover found/created flag values, raw-document assertions proving the flag never reaches storage (including via the upsert filter), `create()`/`save()`/`find()` flag transitions, and sequential `firstOrCreate` idempotency. Full suite: 176/176 passing; lint, typecheck, and build clean.

Closes #69
