### PR TITLE
feat: add chunk() and cursor() for batch iteration

### DIFF
--- a/packages/esix/src/base-model.ts
+++ b/packages/esix/src/base-model.ts
@@ -66,7 +66,10 @@ export default class BaseModel {
   /**
    * Processes all models in batches of `size`. Batches are fetched with
    * keyset pagination on the id in ascending order, so it is safe to update
-   * or delete the models handed to the callback while iterating.
+   * or delete the models handed to the callback while iterating. The
+   * collection's `_id`s must all be the same BSON type (esix itself always
+   * creates string ids); mixed-type collections will only iterate the first
+   * type bracket.
    *
    * Return `false` from the callback to stop processing early.
    *
@@ -88,7 +91,7 @@ export default class BaseModel {
   static async chunk<T extends BaseModel>(
     this: ObjectType<T>,
     size: number,
-    callback: (models: T[], page: number) => unknown | Promise<unknown>
+    callback: (models: T[], page: number) => unknown
   ): Promise<boolean> {
     return new QueryBuilder(this).chunk(size, callback)
   }
@@ -158,7 +161,9 @@ export default class BaseModel {
    * Returns an async iterator over all models, fetching documents in
    * batches of `batchSize` behind the scenes. Iteration uses keyset
    * pagination on the id in ascending order, so it is safe to update or
-   * delete models while iterating.
+   * delete models while iterating. The collection's `_id`s must all be the
+   * same BSON type (esix itself always creates string ids); mixed-type
+   * collections will only iterate the first type bracket.
    *
    * Example
    * ```

--- a/packages/esix/src/base-model.ts
+++ b/packages/esix/src/base-model.ts
@@ -64,6 +64,36 @@ export default class BaseModel {
   }
 
   /**
+   * Processes all models in batches of `size`. Batches are fetched with
+   * keyset pagination on the id in ascending order, so it is safe to update
+   * or delete the models handed to the callback while iterating.
+   *
+   * Return `false` from the callback to stop processing early.
+   *
+   * Example
+   * ```
+   * await Book.chunk(500, async (books) => {
+   *   for (const book of books) {
+   *     await enrich(book);
+   *   }
+   * });
+   * ```
+   *
+   * @param size The number of models per batch.
+   * @param callback Called with each batch of models and the page number,
+   *   starting at 1.
+   * @returns `false` if the callback stopped the iteration early, `true`
+   *   otherwise.
+   */
+  static async chunk<T extends BaseModel>(
+    this: ObjectType<T>,
+    size: number,
+    callback: (models: T[], page: number) => unknown | Promise<unknown>
+  ): Promise<boolean> {
+    return new QueryBuilder(this).chunk(size, callback)
+  }
+
+  /**
    * Returns the number of documents for this model.
    *
    * Example
@@ -122,6 +152,28 @@ export default class BaseModel {
     }
 
     return model
+  }
+
+  /**
+   * Returns an async iterator over all models, fetching documents in
+   * batches of `batchSize` behind the scenes. Iteration uses keyset
+   * pagination on the id in ascending order, so it is safe to update or
+   * delete models while iterating.
+   *
+   * Example
+   * ```
+   * for await (const book of Book.cursor()) {
+   *   await enrich(book);
+   * }
+   * ```
+   *
+   * @param batchSize The number of documents fetched per batch.
+   */
+  static cursor<T extends BaseModel>(
+    this: ObjectType<T>,
+    batchSize?: number
+  ): AsyncGenerator<T, void, undefined> {
+    return new QueryBuilder(this).cursor(batchSize)
   }
 
   /**

--- a/packages/esix/src/batch-iteration.spec.ts
+++ b/packages/esix/src/batch-iteration.spec.ts
@@ -54,6 +54,60 @@ describe('chunk', () => {
     expect(new Set(seenIds).size).toEqual(25)
   })
 
+  it('does not invoke an empty extra callback when the count is a multiple of the size.', async () => {
+    for (let i = 0; i < 20; i++) {
+      await Post.create({ title: `Post ${i}` })
+    }
+
+    const batchSizes: number[] = []
+    const pages: number[] = []
+
+    const result = await Post.chunk(10, (posts, page) => {
+      batchSizes.push(posts.length)
+      pages.push(page)
+    })
+
+    expect(result).toEqual(true)
+    expect(batchSizes).toEqual([10, 10])
+    expect(pages).toEqual([1, 2])
+  })
+
+  it('processes a single partial batch when the size exceeds the total.', async () => {
+    for (let i = 0; i < 5; i++) {
+      await Post.create({ title: `Post ${i}` })
+    }
+
+    const batchSizes: number[] = []
+
+    await Post.chunk(10, (posts) => {
+      batchSizes.push(posts.length)
+    })
+
+    expect(batchSizes).toEqual([5])
+  })
+
+  it('preserves an existing id condition from whereIn.', async () => {
+    const createdIds: string[] = []
+
+    for (let i = 0; i < 8; i++) {
+      const post = await Post.create({ title: `Post ${i}` })
+
+      createdIds.push(post.id)
+    }
+
+    const subset = createdIds.slice(0, 5)
+    const seenIds: string[] = []
+
+    await Post.whereIn('id', subset).chunk(2, (posts) => {
+      for (const post of posts) {
+        seenIds.push(post.id)
+      }
+    })
+
+    expect(seenIds.sort()).toEqual([...subset].sort())
+    expect(new Set(seenIds).size).toEqual(5)
+  })
+
   it('only processes documents matching the current query.', async () => {
     for (let i = 0; i < 6; i++) {
       await Post.create({ title: `Post ${i}`, published: i % 2 === 0 })

--- a/packages/esix/src/batch-iteration.spec.ts
+++ b/packages/esix/src/batch-iteration.spec.ts
@@ -1,0 +1,257 @@
+import mongodb from 'mongo-mock'
+import { v1 as createUuid } from 'uuid'
+import { afterAll, beforeEach, describe, expect, it } from 'vitest'
+
+import { BaseModel } from './'
+import { connectionHandler } from './connection-handler'
+
+mongodb.max_delay = 1
+
+class Post extends BaseModel {
+  public title = ''
+  public published = false
+  public views = 0
+}
+
+describe('chunk', () => {
+  beforeEach(() => {
+    Object.assign(process.env, {
+      DB_ADAPTER: 'mock',
+      DB_DATABASE: `test-${createUuid()}`
+    })
+  })
+
+  afterAll(() => {
+    connectionHandler.closeConnections()
+  })
+
+  it('processes all documents in batches with page numbers.', async () => {
+    const createdIds: string[] = []
+
+    for (let i = 0; i < 25; i++) {
+      const post = await Post.create({ title: `Post ${i}` })
+
+      createdIds.push(post.id)
+    }
+
+    const batchSizes: number[] = []
+    const pages: number[] = []
+    const seenIds: string[] = []
+
+    const result = await Post.chunk(10, (posts, page) => {
+      batchSizes.push(posts.length)
+      pages.push(page)
+
+      for (const post of posts) {
+        seenIds.push(post.id)
+      }
+    })
+
+    expect(result).toEqual(true)
+    expect(batchSizes).toEqual([10, 10, 5])
+    expect(pages).toEqual([1, 2, 3])
+    expect(seenIds.sort()).toEqual(createdIds.sort())
+    expect(new Set(seenIds).size).toEqual(25)
+  })
+
+  it('only processes documents matching the current query.', async () => {
+    for (let i = 0; i < 6; i++) {
+      await Post.create({ title: `Post ${i}`, published: i % 2 === 0 })
+    }
+
+    const seenTitles: string[] = []
+
+    await Post.where('published', true).chunk(2, (posts) => {
+      for (const post of posts) {
+        seenTitles.push(post.title)
+      }
+    })
+
+    expect(seenTitles.sort()).toEqual(['Post 0', 'Post 2', 'Post 4'])
+  })
+
+  it('stops early when the callback returns false.', async () => {
+    for (let i = 0; i < 25; i++) {
+      await Post.create({ title: `Post ${i}` })
+    }
+
+    let invocations = 0
+
+    const result = await Post.chunk(10, () => {
+      invocations += 1
+
+      return false
+    })
+
+    expect(result).toEqual(false)
+    expect(invocations).toEqual(1)
+  })
+
+  it('processes every document when the callback mutates the query fields.', async () => {
+    for (let i = 0; i < 20; i++) {
+      await Post.create({ title: `Post ${i}`, published: false })
+    }
+
+    await Post.where('published', false).chunk(5, async (posts) => {
+      for (const post of posts) {
+        post.published = true
+
+        await post.save()
+      }
+    })
+
+    const publishedCount = await Post.where('published', true).count()
+    const unpublishedCount = await Post.where('published', false).count()
+
+    expect(publishedCount).toEqual(20)
+    expect(unpublishedCount).toEqual(0)
+  })
+
+  it('processes every document exactly once when batches are deleted.', async () => {
+    for (let i = 0; i < 12; i++) {
+      await Post.create({ title: `Post ${i}` })
+    }
+
+    const seenIds: string[] = []
+
+    await Post.chunk(4, async (posts) => {
+      for (const post of posts) {
+        seenIds.push(post.id)
+
+        await post.delete()
+      }
+    })
+
+    expect(new Set(seenIds).size).toEqual(12)
+    expect(await Post.count()).toEqual(0)
+  })
+
+  it('never invokes the callback when no documents match.', async () => {
+    await Post.create({ title: 'Draft', published: false })
+
+    let invocations = 0
+
+    const result = await Post.where('published', true).chunk(10, () => {
+      invocations += 1
+    })
+
+    expect(result).toEqual(true)
+    expect(invocations).toEqual(0)
+  })
+
+  it('throws on an invalid size.', async () => {
+    await expect(Post.chunk(0, () => {})).rejects.toThrow(/size/)
+    await expect(Post.chunk(-1, () => {})).rejects.toThrow(/size/)
+    await expect(Post.chunk(1.5, () => {})).rejects.toThrow(/size/)
+  })
+
+  it('processes every document exactly once even when orderBy is set.', async () => {
+    const createdIds: string[] = []
+
+    for (let i = 0; i < 15; i++) {
+      const post = await Post.create({ title: `Post ${i}` })
+
+      createdIds.push(post.id)
+    }
+
+    const seenIds: string[] = []
+
+    await Post.orderBy('title', 'desc').chunk(4, (posts) => {
+      for (const post of posts) {
+        seenIds.push(post.id)
+      }
+    })
+
+    expect(seenIds.sort()).toEqual(createdIds.sort())
+    expect(new Set(seenIds).size).toEqual(15)
+  })
+})
+
+describe('cursor', () => {
+  beforeEach(() => {
+    Object.assign(process.env, {
+      DB_ADAPTER: 'mock',
+      DB_DATABASE: `test-${createUuid()}`
+    })
+  })
+
+  afterAll(() => {
+    connectionHandler.closeConnections()
+  })
+
+  it('yields every model in ascending id order across batch boundaries.', async () => {
+    const createdIds: string[] = []
+
+    for (let i = 0; i < 10; i++) {
+      const post = await Post.create({ title: `Post ${i}` })
+
+      createdIds.push(post.id)
+    }
+
+    const seenIds: string[] = []
+
+    for await (const post of Post.cursor(3)) {
+      seenIds.push(post.id)
+    }
+
+    expect(seenIds).toEqual([...createdIds].sort())
+    expect(new Set(seenIds).size).toEqual(10)
+  })
+
+  it('respects where constraints.', async () => {
+    for (let i = 0; i < 6; i++) {
+      await Post.create({ title: `Post ${i}`, published: i % 2 === 0 })
+    }
+
+    const seenTitles: string[] = []
+
+    for await (const post of Post.where('published', true).cursor(2)) {
+      seenTitles.push(post.title)
+    }
+
+    expect(seenTitles.sort()).toEqual(['Post 0', 'Post 2', 'Post 4'])
+  })
+
+  it('supports iterating the query builder directly.', async () => {
+    for (let i = 0; i < 4; i++) {
+      await Post.create({ title: `Post ${i}`, published: true })
+    }
+
+    await Post.create({ title: 'Draft', published: false })
+
+    const seenTitles: string[] = []
+
+    for await (const post of Post.where('published', true)) {
+      seenTitles.push(post.title)
+    }
+
+    expect(seenTitles.sort()).toEqual(['Post 0', 'Post 1', 'Post 2', 'Post 3'])
+  })
+
+  it('exits cleanly when breaking out of the loop.', async () => {
+    for (let i = 0; i < 10; i++) {
+      await Post.create({ title: `Post ${i}` })
+    }
+
+    let seen = 0
+
+    for await (const post of Post.cursor(3)) {
+      expect(post.id).not.toEqual('')
+
+      seen += 1
+
+      if (seen === 4) {
+        break
+      }
+    }
+
+    expect(seen).toEqual(4)
+    expect(await Post.count()).toEqual(10)
+  })
+
+  it('throws on an invalid batch size.', async () => {
+    expect(() => Post.cursor(0)).toThrow(/batchSize/)
+    expect(() => Post.cursor(-1)).toThrow(/batchSize/)
+    expect(() => Post.cursor(1.5)).toThrow(/batchSize/)
+  })
+})

--- a/packages/esix/src/batch-iteration.spec.ts
+++ b/packages/esix/src/batch-iteration.spec.ts
@@ -124,6 +124,47 @@ describe('chunk', () => {
     expect(seenTitles.sort()).toEqual(['Post 0', 'Post 2', 'Post 4'])
   })
 
+  it('processes the union of conditions exactly once each with orWhere.', async () => {
+    const expectedIds: string[] = []
+
+    for (let i = 0; i < 5; i++) {
+      const post = await Post.create({
+        title: `Published ${i}`,
+        published: true,
+        views: 0
+      })
+
+      expectedIds.push(post.id)
+    }
+
+    for (let i = 0; i < 5; i++) {
+      const post = await Post.create({
+        title: `Popular ${i}`,
+        published: false,
+        views: 200
+      })
+
+      expectedIds.push(post.id)
+    }
+
+    for (let i = 0; i < 5; i++) {
+      await Post.create({ title: `Ignored ${i}`, published: false, views: 1 })
+    }
+
+    const seenIds: string[] = []
+
+    await Post.where('published', true)
+      .orWhere('views', '>', 100)
+      .chunk(3, (posts) => {
+        for (const post of posts) {
+          seenIds.push(post.id)
+        }
+      })
+
+    expect(seenIds.sort()).toEqual([...expectedIds].sort())
+    expect(new Set(seenIds).size).toEqual(10)
+  })
+
   it('stops early when the callback returns false.', async () => {
     for (let i = 0; i < 25; i++) {
       await Post.create({ title: `Post ${i}` })
@@ -264,6 +305,45 @@ describe('cursor', () => {
     }
 
     expect(seenTitles.sort()).toEqual(['Post 0', 'Post 2', 'Post 4'])
+  })
+
+  it('yields the union of conditions exactly once each with orWhere.', async () => {
+    const expectedIds: string[] = []
+
+    for (let i = 0; i < 4; i++) {
+      const post = await Post.create({
+        title: `Published ${i}`,
+        published: true,
+        views: 0
+      })
+
+      expectedIds.push(post.id)
+    }
+
+    for (let i = 0; i < 4; i++) {
+      const post = await Post.create({
+        title: `Popular ${i}`,
+        published: false,
+        views: 200
+      })
+
+      expectedIds.push(post.id)
+    }
+
+    for (let i = 0; i < 4; i++) {
+      await Post.create({ title: `Ignored ${i}`, published: false, views: 1 })
+    }
+
+    const seenIds: string[] = []
+
+    for await (const post of Post.where('published', true)
+      .orWhere('views', '>', 100)
+      .cursor(3)) {
+      seenIds.push(post.id)
+    }
+
+    expect(seenIds.sort()).toEqual([...expectedIds].sort())
+    expect(new Set(seenIds).size).toEqual(8)
   })
 
   it('supports iterating the query builder directly.', async () => {

--- a/packages/esix/src/query-builder.ts
+++ b/packages/esix/src/query-builder.ts
@@ -989,18 +989,21 @@ export default class QueryBuilder<T extends BaseModel> {
   /**
    * Fetches the next batch of raw documents for keyset pagination. The
    * batch is sorted by `_id` ascending and, when `lastId` is set, only
-   * contains documents with an id greater than `lastId`. The base query is
-   * combined with the id constraint using `$and` so existing `_id`
-   * conditions (e.g. from `whereIn('id', ...)`) are preserved.
+   * contains documents with an id greater than `lastId`. The base query,
+   * including any OR groups added through `orWhere`, is combined with the
+   * id constraint using `$and` so existing `_id` conditions (e.g. from
+   * `whereIn('id', ...)`) are preserved.
    */
   private async fetchBatch(lastId: unknown, size: number): Promise<Document[]> {
+    const baseQuery = this.buildQuery()
+
     return this.useCollection(async (collection) => {
       let query: Query
 
       if (lastId === undefined) {
-        query = this.query
-      } else if (Object.keys(this.query).length > 0) {
-        query = { $and: [this.query, { _id: { $gt: lastId } }] }
+        query = baseQuery
+      } else if (Object.keys(baseQuery).length > 0) {
+        query = { $and: [baseQuery, { _id: { $gt: lastId } }] }
       } else {
         query = { _id: { $gt: lastId } }
       }
@@ -1014,7 +1017,7 @@ export default class QueryBuilder<T extends BaseModel> {
 
         return documents.filter((document) => document)
       } catch (error) {
-        if (isTextIndexMissingError(error, this.query)) {
+        if (isTextIndexMissingError(error, baseQuery)) {
           throw new Error(
             `search() requires a text index on the "${collection.collectionName}" collection. ` +
               `Create one with db["${collection.collectionName}"].createIndex({ "<field>": "text" }).`,

--- a/packages/esix/src/query-builder.ts
+++ b/packages/esix/src/query-builder.ts
@@ -100,6 +100,74 @@ export default class QueryBuilder<T extends BaseModel> {
   }
 
   /**
+   * Processes all models matching the current query in batches of `size`.
+   *
+   * Batches are fetched with keyset pagination on `_id` in ascending order,
+   * so it is safe to update or delete the models handed to the callback
+   * while iterating. Any `orderBy()`, `limit()`, or `skip()` set on the
+   * builder is ignored: resumable keyset pagination requires a unique total
+   * order, so iteration is always by id ascending.
+   *
+   * Return `false` from the callback to stop processing early.
+   *
+   * Example
+   * ```
+   * await Post.where('published', false).chunk(500, async (posts, page) => {
+   *   for (const post of posts) {
+   *     post.published = true;
+   *
+   *     await post.save();
+   *   }
+   * });
+   * ```
+   *
+   * @param size The number of models per batch.
+   * @param callback Called with each batch of models and the page number,
+   *   starting at 1.
+   * @returns `false` if the callback stopped the iteration early, `true`
+   *   otherwise.
+   */
+  async chunk(
+    size: number,
+    callback: (models: T[], page: number) => unknown | Promise<unknown>
+  ): Promise<boolean> {
+    if (!Number.isInteger(size) || size < 1) {
+      throw new Error(`chunk() size must be an integer >= 1, received: ${size}`)
+    }
+
+    let lastId: unknown = undefined
+    let page = 1
+
+    while (true) {
+      const documents = await this.fetchBatch(lastId, size)
+
+      if (documents.length === 0) {
+        break
+      }
+
+      lastId = documents[documents.length - 1]._id
+
+      const models = documents.map(
+        (document): T => this.createInstance(document)
+      )
+
+      const result = await callback(models, page)
+
+      if (result === false) {
+        return false
+      }
+
+      if (documents.length < size) {
+        break
+      }
+
+      page += 1
+    }
+
+    return true
+  }
+
+  /**
    * Returns the number of documents matching the given query.
    *
    * Example
@@ -131,6 +199,50 @@ export default class QueryBuilder<T extends BaseModel> {
 
       return insertedId
     })
+  }
+
+  /**
+   * Returns an async iterator over all models matching the current query,
+   * fetching documents in batches of `batchSize` behind the scenes.
+   *
+   * Batches are fetched with keyset pagination on `_id` in ascending order,
+   * so it is safe to update or delete models while iterating. Any
+   * `orderBy()`, `limit()`, or `skip()` set on the builder is ignored:
+   * resumable keyset pagination requires a unique total order, so iteration
+   * is always by id ascending.
+   *
+   * Example
+   * ```
+   * for await (const post of Post.where('published', true).cursor()) {
+   *   console.log(post.title);
+   * }
+   * ```
+   *
+   * @param batchSize The number of documents fetched per batch.
+   */
+  cursor(batchSize = 1000): AsyncGenerator<T, void, undefined> {
+    if (!Number.isInteger(batchSize) || batchSize < 1) {
+      throw new Error(
+        `cursor() batchSize must be an integer >= 1, received: ${batchSize}`
+      )
+    }
+
+    return this.iterate(batchSize)
+  }
+
+  /**
+   * Makes the QueryBuilder itself async iterable, so it can be used
+   * directly in a `for await` loop. Equivalent to iterating `cursor()`.
+   *
+   * Example
+   * ```
+   * for await (const post of Post.where('published', true)) {
+   *   console.log(post.title);
+   * }
+   * ```
+   */
+  [Symbol.asyncIterator](): AsyncIterator<T> {
+    return this.cursor()
   }
 
   /**
@@ -720,6 +832,63 @@ export default class QueryBuilder<T extends BaseModel> {
         throw error
       }
     })
+  }
+
+  /**
+   * Fetches the next batch of raw documents for keyset pagination. The
+   * batch is sorted by `_id` ascending and, when `lastId` is set, only
+   * contains documents with an id greater than `lastId`. The base query is
+   * combined with the id constraint using `$and` so existing `_id`
+   * conditions (e.g. from `whereIn('id', ...)`) are preserved.
+   */
+  private async fetchBatch(lastId: unknown, size: number): Promise<Document[]> {
+    return this.useCollection(async (collection) => {
+      let query: Query
+
+      if (lastId === undefined) {
+        query = this.query
+      } else if (Object.keys(this.query).length > 0) {
+        query = { $and: [this.query, { _id: { $gt: lastId } }] }
+      } else {
+        query = { _id: { $gt: lastId } }
+      }
+
+      const documents = await collection
+        .find(query)
+        .sort({ _id: 1 })
+        .limit(size)
+        .toArray()
+
+      return documents.filter((document) => document)
+    })
+  }
+
+  /**
+   * Yields models matching the current query one at a time, fetching the
+   * underlying documents in batches of `batchSize` via keyset pagination.
+   */
+  private async *iterate(
+    batchSize: number
+  ): AsyncGenerator<T, void, undefined> {
+    let lastId: unknown = undefined
+
+    while (true) {
+      const documents = await this.fetchBatch(lastId, batchSize)
+
+      if (documents.length === 0) {
+        return
+      }
+
+      lastId = documents[documents.length - 1]._id
+
+      for (const document of documents) {
+        yield this.createInstance(document)
+      }
+
+      if (documents.length < batchSize) {
+        return
+      }
+    }
   }
 
   private async useCollection<K>(

--- a/packages/esix/src/query-builder.ts
+++ b/packages/esix/src/query-builder.ts
@@ -108,6 +108,10 @@ export default class QueryBuilder<T extends BaseModel> {
    * builder is ignored: resumable keyset pagination requires a unique total
    * order, so iteration is always by id ascending.
    *
+   * The collection's `_id`s must all be the same BSON type (esix itself
+   * always creates string ids); mixed-type collections will only iterate
+   * the first type bracket.
+   *
    * Return `false` from the callback to stop processing early.
    *
    * Example
@@ -129,7 +133,7 @@ export default class QueryBuilder<T extends BaseModel> {
    */
   async chunk(
     size: number,
-    callback: (models: T[], page: number) => unknown | Promise<unknown>
+    callback: (models: T[], page: number) => unknown
   ): Promise<boolean> {
     if (!Number.isInteger(size) || size < 1) {
       throw new Error(`chunk() size must be an integer >= 1, received: ${size}`)
@@ -210,6 +214,10 @@ export default class QueryBuilder<T extends BaseModel> {
    * `orderBy()`, `limit()`, or `skip()` set on the builder is ignored:
    * resumable keyset pagination requires a unique total order, so iteration
    * is always by id ascending.
+   *
+   * The collection's `_id`s must all be the same BSON type (esix itself
+   * always creates string ids); mixed-type collections will only iterate
+   * the first type bracket.
    *
    * Example
    * ```
@@ -853,13 +861,24 @@ export default class QueryBuilder<T extends BaseModel> {
         query = { _id: { $gt: lastId } }
       }
 
-      const documents = await collection
-        .find(query)
-        .sort({ _id: 1 })
-        .limit(size)
-        .toArray()
+      try {
+        const documents = await collection
+          .find(query)
+          .sort({ _id: 1 })
+          .limit(size)
+          .toArray()
 
-      return documents.filter((document) => document)
+        return documents.filter((document) => document)
+      } catch (error) {
+        if (isTextIndexMissingError(error, this.query)) {
+          throw new Error(
+            `search() requires a text index on the "${collection.collectionName}" collection. ` +
+              `Create one with db["${collection.collectionName}"].createIndex({ "<field>": "text" }).`,
+            { cause: error }
+          )
+        }
+        throw error
+      }
     })
   }
 

--- a/packages/website/docs.json
+++ b/packages/website/docs.json
@@ -33,7 +33,7 @@
           },
           {
             "group": "Querying",
-            "pages": ["docs/pagination"]
+            "pages": ["docs/pagination", "docs/batch-processing"]
           },
           {
             "group": "Guides",

--- a/packages/website/docs/batch-processing.md
+++ b/packages/website/docs/batch-processing.md
@@ -1,0 +1,128 @@
+---
+title: Batch Processing
+description: Process large collections without loading everything into memory. Learn how to iterate over models in batches with Esix's chunk helper and async cursor.
+---
+
+Methods like `all()` and `get()` load every matching document into memory at
+once. That's fine for a few hundred records, but batch jobs that enrich,
+migrate, or clean up whole collections need a way to work through documents a
+handful at a time. Esix provides two helpers for this: `chunk` and `cursor`.
+
+Both fetch documents in batches using keyset pagination on the id, so memory
+usage stays flat no matter how large the collection is.
+
+## chunk()
+
+`chunk(size, callback)` fetches models in batches of `size` and hands each
+batch to your callback along with a page number, starting at 1:
+
+```ts
+await Book.chunk(500, async (books, page) => {
+  console.log(`Processing page ${page} with ${books.length} books`)
+
+  for (const book of books) {
+    await enrich(book)
+  }
+})
+```
+
+```
+Processing page 1 with 500 books
+Processing page 2 with 500 books
+Processing page 3 with 137 books
+```
+
+`chunk` works on any query, so you can constrain which documents are
+processed:
+
+```ts
+await Post.where('published', false).chunk(100, async (posts) => {
+  for (const post of posts) {
+    post.published = true
+
+    await post.save()
+  }
+})
+```
+
+`chunk` resolves to `true` once every batch has been processed.
+
+### Stopping Early
+
+Return `false` from the callback to stop processing further batches. `chunk`
+then resolves to `false`:
+
+```ts
+const completed = await Order.chunk(100, async (orders) => {
+  const failed = await processPayments(orders)
+
+  if (failed) {
+    return false
+  }
+})
+
+console.log(completed)
+```
+
+```
+false
+```
+
+## cursor()
+
+When you'd rather work with one model at a time, `cursor()` returns an async
+iterator. Documents are still fetched in batches behind the scenes (1,000 per
+batch by default), but your loop sees a steady stream of models:
+
+```ts
+for await (const book of Book.cursor()) {
+  await enrich(book)
+}
+```
+
+You can tune the batch size and combine it with queries:
+
+```ts
+for await (const post of Post.where('published', true).cursor(250)) {
+  console.log(post.title)
+}
+```
+
+Query builders are also directly async iterable, so you can skip the `cursor()`
+call entirely:
+
+```ts
+for await (const post of Post.where('published', true)) {
+  console.log(post.title)
+}
+```
+
+Breaking out of a `for await` loop is safe and stops fetching further batches:
+
+```ts
+for await (const user of User.cursor()) {
+  if (await needsAttention(user)) {
+    await notify(user)
+
+    break
+  }
+}
+```
+
+## Iteration Order and Mutation Safety
+
+Both `chunk` and `cursor` iterate documents by id in ascending order. After
+each batch, the next batch is fetched with an "id greater than the last one
+seen" condition rather than a numeric offset. This has two important
+consequences:
+
+- **Mutation safety.** It is safe to update or delete the models you've been
+  handed while iterating. A hand-rolled `skip`/`limit` loop silently skips
+  documents when the loop body changes which documents match the query;
+  keyset pagination does not.
+- **Fixed ordering.** Any `orderBy()`, `limit()`, or `skip()` set on the
+  query is ignored by `chunk` and `cursor`. Resumable keyset pagination
+  requires a unique total order, so iteration is always by id ascending.
+
+If you need results in a custom order or a single bounded page, use
+[pagination](/docs/pagination) instead.

--- a/packages/website/docs/batch-processing.md
+++ b/packages/website/docs/batch-processing.md
@@ -124,5 +124,11 @@ consequences:
   query is ignored by `chunk` and `cursor`. Resumable keyset pagination
   requires a unique total order, so iteration is always by id ascending.
 
+One limitation to be aware of: the collection's `_id`s must all be the same
+BSON type. Documents created through Esix always use string ids, and
+collections created by other tools usually use `ObjectId`s throughout —
+both work fine. But a mixed-type collection will only iterate the first
+type bracket, because MongoDB's `$gt` never matches across BSON types.
+
 If you need results in a custom order or a single bounded page, use
 [pagination](/docs/pagination) instead.

--- a/packages/website/docs/pagination.md
+++ b/packages/website/docs/pagination.md
@@ -67,6 +67,10 @@ const products = await Product.where('category', 'electronics')
 | `60119e8a9f1b2c4d8e7f3a22` | `Smart Bulb`        | `electronics` | 14.99 |
 | `60119e8a9f1b2c4d8e7f3a23` | `USB-C Hub`         | `electronics` | 34.50 |
 
+If you are looping over `skip`/`limit` pages to process a whole collection,
+use [batch processing](/docs/batch-processing) with `chunk` or `cursor`
+instead. Offset loops can skip documents when the loop body modifies them.
+
 ## Pagination with Sorting
 
 When paginating, it's important to use consistent sorting to ensure stable


### PR DESCRIPTION
## Summary

Adds built-in batch iteration so jobs no longer hand-roll `skip`/`limit` loops (#70):

- **`Model.chunk(size, callback)`** — processes models in batches; the callback receives each batch plus a 1-indexed page number, and returning `false` stops iteration early (`chunk` then resolves `false`).
- **`Model.cursor(batchSize = 1000)`** — an async iterator yielding one model at a time while fetching in batches behind the scenes: `for await (const book of Book.cursor()) { ... }`.
- **Direct `for await` on the query builder** — `QueryBuilder` implements `Symbol.asyncIterator`, so `for await (const post of Post.where('published', true))` works without calling `cursor()`.

Both are available on `QueryBuilder` (chainable after `where`/`whereIn`/etc.) and as statics on `BaseModel`.

## Design: id-keyset pagination

Batches are fetched by sorting `_id` ascending and requesting `limit(size)` documents with `_id` greater than the last id seen, composed with the base query via `$and` so existing `_id` conditions (e.g. `whereIn('id', ...)`) are preserved. The pagination boundary is tracked from the raw document `_id` (not the model's hex-string `id`), so collections with driver-created `ObjectId` ids paginate correctly.

Why keyset instead of the alternatives:

- **Mutation-safe, unlike `skip`/`limit`:** offset loops silently skip documents when the loop body updates or deletes documents that affect the query — the exact bug from the issue. Keyset iteration processes every document exactly once even when batches are mutated or deleted mid-iteration (Laravel `chunkById` semantics; covered by regression tests).
- **Works on both adapters:** uses only `find`/`sort`/`limit`/`toArray`, which the mock adapter supports. mongo-mock's native cursor lacks `hasNext`, throws on `batchSize()`, and re-filters the live array on `next()`.
- **No native-cursor timeout risk:** each batch is an independent query, so long-running callbacks can't hit server-side idle cursor timeouts.

## Contract

- `chunk`/`cursor` **ignore `orderBy()`, `limit()`, and `skip()`**: resumable keyset pagination requires a unique total order, so iteration is always by id ascending. Documented in JSDoc and the docs page.
- The collection's `_id`s must all be the **same BSON type** (esix always creates string ids; all-`ObjectId` external collections also work). Mixed-type collections only iterate the first type bracket, because `$gt` never matches across BSON types. Documented in JSDoc and the docs page.
- `size`/`batchSize` must be integers >= 1, mirroring `paginate()`'s validation.
- `search().chunk(...)` surfaces the same friendly missing-text-index error as `get()`.

## Docs

- New **Batch Processing** page (`docs/batch-processing`): motivation, `chunk` with example output, early stop, `cursor`/`for await`, direct builder iteration, id-order guarantee, mutation safety, ignored `orderBy`/`limit`/`skip`, and the homogeneous-`_id` note.
- Added to the **Querying** nav group in `docs.json` (after Pagination); cross-linked from the manual `skip`/`limit` section of the Pagination page. `mintlify broken-links` passes.

## Tests

16 new mongo-mock integration tests in `batch-iteration.spec.ts`: batch sizes/page numbers (including exact-multiple counts and oversized sizes), `where`/`whereIn` composition, early stop, the issue's mutate-while-chunking regression case, delete-while-chunking, empty matches, argument validation, cross-batch ordering without duplicates or omissions, direct builder iteration, clean `break`, and the ignored-`orderBy` contract.

## Merge order

**This PR should merge LAST of the open feature PRs (#72/#73/#74).** The branch is rebased onto main with #71 (`whereNull`/`whereNotNull`/`orWhere`) already merged, and `fetchBatch` now reads the base query via `buildQuery()`, so `chunk`/`cursor` fully respect `orWhere` groups (with pinning tests for both `chunk` and `cursor`).

Closes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)
