### PR TITLE
feat: add custom collection names via static collectionName

### DIFF
--- a/packages/esix/src/base-model.spec.ts
+++ b/packages/esix/src/base-model.spec.ts
@@ -27,7 +27,7 @@ const collection = {
   aggregate: vi.fn()
 }
 const database = {
-  collection: () => Promise.resolve(collection)
+  collection: vi.fn(() => Promise.resolve(collection))
 }
 const client = {
   db: () => database
@@ -142,6 +142,75 @@ describe('BaseModel', () => {
       expect(collection.find).toHaveBeenCalledWith({})
 
       expect(books).toEqual([])
+    })
+  })
+
+  describe('collectionName', () => {
+    class Invoice extends BaseModel {
+      static collectionName = 'billing_invoices'
+
+      public amount = 0
+    }
+
+    it('uses the custom collection name when reading.', async () => {
+      const cursor = createCursor([])
+
+      collection.find.mockReturnValue(cursor)
+
+      await Invoice.all()
+
+      expect(database.collection).toHaveBeenCalledWith('billing_invoices')
+    })
+
+    it('uses the custom collection name when writing.', async () => {
+      collection.insertOne.mockResolvedValue({
+        insertedId: '5f3568f2a0cdd1c9ba411c43'
+      })
+      collection.findOne.mockResolvedValue({
+        _id: '5f3568f2a0cdd1c9ba411c43',
+        amount: 100,
+        createdAt: 1594552340652,
+        updatedAt: null
+      })
+
+      await Invoice.create({ amount: 100 })
+
+      expect(database.collection).toHaveBeenCalledWith('billing_invoices')
+    })
+
+    it('uses the custom collection name when deleting.', async () => {
+      collection.deleteOne.mockReturnValue({
+        deletedCount: 1
+      })
+
+      const invoice = new Invoice()
+      invoice.id = '5f3568f2a0cdd1c9ba411c43'
+
+      await invoice.delete()
+
+      expect(database.collection).toHaveBeenCalledWith('billing_invoices')
+    })
+
+    it('falls back to the inferred collection name.', async () => {
+      const cursor = createCursor([])
+
+      collection.find.mockReturnValue(cursor)
+
+      await Book.all()
+
+      expect(database.collection).toHaveBeenCalledWith('books')
+    })
+
+    it('inherits the custom collection name in subclasses.', async () => {
+      class PaidInvoice extends Invoice {}
+
+      const cursor = createCursor([])
+
+      collection.find.mockReturnValue(cursor)
+
+      await PaidInvoice.all()
+
+      expect(database.collection).toHaveBeenCalledWith('billing_invoices')
     })
   })
 

--- a/packages/esix/src/base-model.ts
+++ b/packages/esix/src/base-model.ts
@@ -11,6 +11,20 @@ import type {
 import { camelCase } from 'change-case'
 
 export default class BaseModel {
+  /**
+   * Overrides the MongoDB collection name for this model. When unset, the
+   * name is inferred from the class name (`BlogPost` → `blog-posts`).
+   * Subclasses share the parent's custom name unless they set their own.
+   *
+   * Example
+   * ```
+   * class User extends BaseModel {
+   *   static collectionName = 'app_users'
+   * }
+   * ```
+   */
+  declare static collectionName?: string
+
   public createdAt = 0
   public id = ''
   public updatedAt: number | null = null

--- a/packages/esix/src/index.ts
+++ b/packages/esix/src/index.ts
@@ -1,6 +1,6 @@
 import BaseModel from './base-model'
 import { ConnectionHandler, connectionHandler } from './connection-handler'
-import { getCollectionName } from './naming'
+import { getCollectionName, resolveCollectionName } from './naming'
 import QueryBuilder, { type Query } from './query-builder'
 import {
   type ComparisonOperator,
@@ -16,7 +16,8 @@ export {
   ConnectionHandler,
   QueryBuilder,
   connectionHandler,
-  getCollectionName
+  getCollectionName,
+  resolveCollectionName
 }
 export type {
   ComparisonOperator,

--- a/packages/esix/src/integration-test.spec.ts
+++ b/packages/esix/src/integration-test.spec.ts
@@ -36,6 +36,12 @@ class Flight extends BaseModel {
   public arrival_time = ''
 }
 
+class LegacyOrder extends BaseModel {
+  static collectionName = 'legacy_orders'
+
+  public reference = ''
+}
+
 class Product extends BaseModel {
   public name = ''
   public price = 0
@@ -1092,6 +1098,41 @@ describe('wasRecentlyCreated', () => {
     await existingFlight.save()
 
     expect(existingFlight.wasRecentlyCreated).toBe(false)
+  })
+})
+
+describe('Custom Collection Names', () => {
+  beforeEach(() => {
+    Object.assign(process.env, {
+      DB_ADAPTER: 'mock',
+      DB_DATABASE: `test-${createUuid()}`
+    })
+  })
+
+  it('stores and retrieves models using the custom collection name', async () => {
+    const order = await LegacyOrder.create({ reference: 'ORDER-1' })
+
+    const foundOrder = await LegacyOrder.find(order.id)
+
+    expect(foundOrder).toEqual({
+      createdAt: expect.any(Number),
+      id: order.id,
+      reference: 'ORDER-1',
+      updatedAt: null
+    })
+
+    const orders = await LegacyOrder.all()
+
+    expect(orders).toHaveLength(1)
+
+    // Assert on the raw collection to prove the documents live in the
+    // custom collection rather than the inferred `legacy-orders`.
+    const connection = await connectionHandler.getConnection()
+    const collection = await connection.collection('legacy_orders')
+    const document = await collection.findOne({ _id: order.id as any })
+
+    expect(document).not.toBeNull()
+    expect(document).toHaveProperty('reference', 'ORDER-1')
   })
 })
 

--- a/packages/esix/src/naming.spec.ts
+++ b/packages/esix/src/naming.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { getCollectionName } from './naming'
+import { getCollectionName, resolveCollectionName } from './naming'
 
 describe('getCollectionName', () => {
   it.each([
@@ -12,5 +12,61 @@ describe('getCollectionName', () => {
     ['OAuthToken', 'o-auth-tokens']
   ])('maps %s -> %s', (className, expected) => {
     expect(getCollectionName(className)).toEqual(expected)
+  })
+})
+
+describe('resolveCollectionName', () => {
+  it('returns the custom name when collectionName is set', () => {
+    class User {
+      static collectionName = 'app_users'
+    }
+
+    expect(resolveCollectionName(User)).toEqual('app_users')
+  })
+
+  it('falls back to the inferred name when collectionName is unset', () => {
+    class BlogPost {}
+
+    expect(resolveCollectionName(BlogPost)).toEqual('blog-posts')
+  })
+
+  it('inherits the custom name in subclasses', () => {
+    class User {
+      static collectionName = 'app_users'
+    }
+    class AdminUser extends User {}
+
+    expect(resolveCollectionName(AdminUser)).toEqual('app_users')
+  })
+
+  it('lets a subclass override the inherited custom name', () => {
+    class User {
+      static collectionName = 'app_users'
+    }
+    class AdminUser extends User {
+      static collectionName = 'app_admins'
+    }
+
+    expect(resolveCollectionName(AdminUser)).toEqual('app_admins')
+  })
+
+  it('throws for an empty string', () => {
+    class User {
+      static collectionName = ''
+    }
+
+    expect(() => resolveCollectionName(User)).toThrow(
+      new TypeError('User.collectionName must be a non-empty string.')
+    )
+  })
+
+  it('throws for a whitespace-only string', () => {
+    class User {
+      static collectionName = '  '
+    }
+
+    expect(() => resolveCollectionName(User)).toThrow(
+      new TypeError('User.collectionName must be a non-empty string.')
+    )
   })
 })

--- a/packages/esix/src/naming.ts
+++ b/packages/esix/src/naming.ts
@@ -1,10 +1,37 @@
 import * as changeCase from 'change-case'
 import pluralize from 'pluralize'
 
+import type { ObjectType } from './types'
+
 /**
  * Returns the canonical MongoDB collection name for a model class name.
  * Example: `BlogPost` → `blog-posts`.
  */
 export function getCollectionName(className: string): string {
   return pluralize(changeCase.kebabCase(className))
+}
+
+/**
+ * Returns the MongoDB collection name for a model class. Uses the class's
+ * static `collectionName` property when set, and falls back to the name
+ * inferred from the class name otherwise.
+ *
+ * @param ctor The model class to resolve the collection name for.
+ * @returns The collection name to use for the model.
+ * @throws {TypeError} If `collectionName` is set but isn't a non-empty string.
+ */
+export function resolveCollectionName<T>(ctor: ObjectType<T>): string {
+  const { collectionName } = ctor
+
+  if (collectionName === undefined) {
+    return getCollectionName(ctor.name)
+  }
+
+  if (typeof collectionName !== 'string' || collectionName.trim() === '') {
+    throw new TypeError(
+      `${ctor.name}.collectionName must be a non-empty string.`
+    )
+  }
+
+  return collectionName
 }

--- a/packages/esix/src/query-builder.ts
+++ b/packages/esix/src/query-builder.ts
@@ -3,7 +3,7 @@ import percentile from 'percentile'
 
 import type BaseModel from './base-model'
 import { connectionHandler } from './connection-handler'
-import { getCollectionName } from './naming'
+import { resolveCollectionName } from './naming'
 import { sanitize } from './sanitize'
 import type {
   ComparisonOperator,
@@ -1174,7 +1174,7 @@ export default class QueryBuilder<T extends BaseModel> {
   private async useCollection<K>(
     block: (collection: Collection) => Promise<any>
   ): Promise<K> {
-    const collectionName = getCollectionName(this.ctor.name)
+    const collectionName = resolveCollectionName(this.ctor)
 
     const connection = await connectionHandler.getConnection()
 

--- a/packages/esix/src/types.ts
+++ b/packages/esix/src/types.ts
@@ -1,8 +1,11 @@
 /**
  * Represents a constructor type for a given model class.
  * Used internally for type-safe model instantiation.
+ *
+ * The optional `collectionName` static lets a model override the
+ * collection name inferred from its class name.
  */
-export type ObjectType<T> = { new (): T }
+export type ObjectType<T> = { new (): T; collectionName?: string }
 
 /**
  * Represents a generic key-value dictionary object.

--- a/packages/website/docs/defining-models.md
+++ b/packages/website/docs/defining-models.md
@@ -54,7 +54,19 @@ The class name is transformed by:
 1. Converting from PascalCase to kebab-case (dashes)
 2. Making it plural
 
-This means you don't need to configure collection names manually - just name your model classes descriptively and Esix handles the rest!
+This means you don't need to configure collection names manually - just name your model classes descriptively and Esix handles the rest! And when the convention doesn't fit, there's an escape hatch.
+
+### Custom Collection Names
+
+Sometimes the conventional name doesn't work - you're pointing Esix at an existing collection, sharing a database with another app, or your build tool minifies class names. Set the static `collectionName` property to override the convention:
+
+```typescript
+class User extends BaseModel {
+  static collectionName = 'app_users'
+}
+```
+
+All queries, writes, and relationships for the model now use the `app_users` collection. Subclasses inherit the custom name unless they define their own.
 
 ## Relationships
 


### PR DESCRIPTION
The collection name is inferred from the model's class name (`BlogPost` → `blog-posts`), which is a great default but had no escape hatch — needed when pointing Esix at an existing collection, sharing a database with another app, or when a build tool minifies class names.

Models can now override the convention with a static property:

```typescript
class User extends BaseModel {
  static collectionName = 'app_users'
}
```

## Implementation

- **`naming.ts`** — new `resolveCollectionName(ctor)` helper: returns `ctor.collectionName` when set, falls back to the existing `getCollectionName(ctor.name)` otherwise. An empty or whitespace-only override throws a `TypeError` instead of silently writing to a wrongly-inferred collection.
- **`query-builder.ts`** — `useCollection` (the single funnel point for all reads, writes, deletes, and relationships) now resolves through the new helper, so the override applies to the entire query surface.
- **`types.ts`** — `ObjectType<T>` gains an optional `collectionName?: string` (structurally non-breaking).
- **`base-model.ts`** — `declare static collectionName?: string` with JSDoc for IntelliSense and the published `.d.ts` (no runtime emit).
- **`index.ts`** — exports `resolveCollectionName` alongside `getCollectionName`.
- **Docs** — new *Custom Collection Names* subsection in `defining-models.md`.

Subclasses inherit the parent's custom name unless they define their own — documented and tested.

Closes #30 